### PR TITLE
docs: verify GenUI on DSH 0.1.1-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### 兼容性
 - **dsh 0.1.0-rc.8**：对齐全部宿主 peer 依赖并补齐实际使用的 conversation、input-trigger、session 直接声明；改用 ui-tool 的公开客户端入口，测试和构建不再读取本机旧源码快照。`tsc`、`tsdown`、Vitest 全通过（316 passed / 104 skipped，0 失败）。
 - **peer 范围放宽至 0.1.1-rc 系列（PR #41）**：strict semver 下 prerelease 版本仅在范围含相同 `major.minor.patch` 元组的比较子时才匹配，`^0.1.0-rc.8` 因此不满足宿主 `0.1.1-rc.1`（marketplace/健康检查误报 unmet peer）。全部 `@deepseek-ai/dsh-*` peer/dev 范围放宽为 `^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0`：保留 rc.8 API 下限、覆盖整个 0.1.1-rc 列车与后续 0.1.x 稳定版、仍排除 0.2.0；pnpm-lock 随新范围重算。
+- **dsh 0.1.1-rc.2**：使用完整 rc.2 宿主依赖验证公开客户端入口、DOM 围栏渲染和面板操作契约；无需增加兼容层，类型检查、构建及 Vitest 全通过（379 passed / 104 skipped，0 失败），并在 rc.2 真实 Web 页面确认客户端激活与资源加载。
 ### 新增
 - **原生音视频组件（issue #35）**：白名单新增 `audio` / `video`，直接播放工具通过 http(s) 或同源相对地址暴露的媒体；两者固定使用原生控制器且不自动播放，支持循环，视频另支持封面、初始静音和 16:9 / 4:3 / 1:1 / 9:16 比例，加载失败原位提示。危险或本地协议被丢弃，未增加播放器依赖。
 - **视觉 E2E 脚本（无需模型 key）**：新增 `scripts/e2e-visual.mts`——真实 dsh web + link 安装 → DOM 通道注入组件画廊 → headless Chrome 全页截图 + 本地交互（排序/判题/折叠/对齐）硬断言。与 `e2e.mjs`（需要 DEEPSEEK_API_KEY 的模型闭环）互补，样式/组件改动后一条命令做视觉回归。


### PR DESCRIPTION
## 结论

GenUI 在 DSH 0.1.1-rc.2 上无需代码兼容层。

## 验证

- 完整 rc.2 宿主依赖下类型检查与构建通过
- Vitest：379 passed / 104 skipped / 0 failed
- rc.2 真实 Web 页面：插件脚本 200、客户端激活、资源加载正常、控制台 0 错误

本 PR 只补充兼容性验证记录。