### PR TITLE
docs: add migration steps for pre-rename installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ npm install @changfenhuang/dsh-genui
 
 > ⚠️ **Don't use `link:` on a freshly cloned directory** — `link:` does not install the plugin's dependencies (mermaid / three / react), so the renderer will break. Use the git URL form above; reserve `link:` for local development iteration (see below).
 
+### Migrating from the old `@omdsh-dev` package name
+
+If you installed the plugin before v0.9.2, remove the old dependency before installing the renamed package:
+
+```sh
+dsh plugin --profile web remove @omdsh-dev/dsh-genui
+dsh plugin --profile web add @changfenhuang/dsh-genui
+```
+
+If `dsh web` still fails and mentions `@omdsh-dev/dsh-genui`, remove only the stale `genui` entry that uses that old name from `~/.dsh/profiles/web/cordis.patch.yml`. The plugin now supplies the `@changfenhuang/dsh-genui` entry itself.
+
 ### Verify the install in 60 seconds
 
 After the command completes, restart dsh web and hard-refresh the browser. In a **new** session, say:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,6 +115,17 @@ npm install @changfenhuang/dsh-genui
 
 > ⚠️ **别用 `link:` 装一个刚 clone 的目录**——`link:` 不会安装插件的依赖（mermaid / three / react），装完渲染器会挂。请用上面的 git URL 方式；只有本地开发迭代才用 link:（见下文）。
 
+### 从旧 `@omdsh-dev` 包名迁移
+
+如果你在 v0.9.2 之前安装过插件，请先删除旧依赖，再安装改名后的包：
+
+```sh
+dsh plugin --profile web remove @omdsh-dev/dsh-genui
+dsh plugin --profile web add @changfenhuang/dsh-genui
+```
+
+如果 `dsh web` 仍然启动失败并提到 `@omdsh-dev/dsh-genui`，请只删除 `~/.dsh/profiles/web/cordis.patch.yml` 中使用该旧名字的 `genui` 登记。插件现在会自行提供 `@changfenhuang/dsh-genui` 登记。
+
 ### 60 秒验证安装
 
 命令完成后，重启 dsh web 并对浏览器硬刷新。在**新**会话中输入：


### PR DESCRIPTION
Closes #48.

Documents the complete recovery path for profiles installed under the old @omdsh-dev scope: remove the stale dependency, install the renamed @changfenhuang package, and remove only a leftover old-scope entry from the user overlay when present. The English and Chinese guides stay aligned.

Verification: git diff --check passed, and the public documentation assertions cover all three migration steps. The same recovery path restored a live local DSH profile, including HTTP 200 for the renamed client bundle.