### PR TITLE
docs: explain GitHub install migration after package rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ npm install @changfenhuang/dsh-genui
 
 ### Migrating from the old `@omdsh-dev` package name
 
-If you installed the plugin before v0.9.2, remove the old dependency before installing the renamed package:
+If you installed from `github:omdsh-dev/dsh-genui` before v0.9.2, pnpm may keep the dependency under the old `@omdsh-dev/dsh-genui` key even though the repository now declares `@changfenhuang/dsh-genui`. The loader resolves plugins from the profile's dependency keys, so a later reinstall can then fail with `Cannot find package '@changfenhuang/dsh-genui'`. Re-add the plugin under its current package name:
 
 ```sh
 dsh plugin --profile web remove @omdsh-dev/dsh-genui
 dsh plugin --profile web add @changfenhuang/dsh-genui
 ```
 
-If `dsh web` still fails and mentions `@omdsh-dev/dsh-genui`, remove only the stale `genui` entry that uses that old name from `~/.dsh/profiles/web/cordis.patch.yml`. The plugin now supplies the `@changfenhuang/dsh-genui` entry itself.
+This migration is required once for old GitHub-spec installs. New npm and GitHub installs created with the commands above use the current dependency key.
 
 ### Verify the install in 60 seconds
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -117,14 +117,14 @@ npm install @changfenhuang/dsh-genui
 
 ### 从旧 `@omdsh-dev` 包名迁移
 
-如果你在 v0.9.2 之前安装过插件，请先删除旧依赖，再安装改名后的包：
+如果你在 v0.9.2 之前通过 `github:omdsh-dev/dsh-genui` 安装过，pnpm 可能仍把依赖保存在旧的 `@omdsh-dev/dsh-genui` 键下，但仓库当前声明的包名已经是 `@changfenhuang/dsh-genui`。加载器按 profile 的依赖键解析插件，后续重装时就可能报 `Cannot find package '@changfenhuang/dsh-genui'`。请用当前包名重新添加一次：
 
 ```sh
 dsh plugin --profile web remove @omdsh-dev/dsh-genui
 dsh plugin --profile web add @changfenhuang/dsh-genui
 ```
 
-如果 `dsh web` 仍然启动失败并提到 `@omdsh-dev/dsh-genui`，请只删除 `~/.dsh/profiles/web/cordis.patch.yml` 中使用该旧名字的 `genui` 登记。插件现在会自行提供 `@changfenhuang/dsh-genui` 登记。
+这次迁移只针对改名前留下的 GitHub 源安装。此后使用上面的 npm 或 GitHub 命令新装，都会采用当前依赖键。
 
 ### 60 秒验证安装
 


### PR DESCRIPTION
## What changed

- explains why legacy GitHub-spec installs can keep the old dependency key after the package rename
- documents the exact remove-and-readd migration using the current package name
- corrects the previous troubleshooting text, which looked for the wrong package name in the error

## Why

DSH resolves bundle rows from profile dependency keys. Existing GitHub-spec installs may remain keyed as @omdsh-dev/dsh-genui while the bundle now imports @changfenhuang/dsh-genui. A package-local relative row is not valid because DSH composes bundle patches against the profile base URL. The safe plugin-side resolution is the one-time migration requested in issue #53.

## Verification

- pnpm check passed locally before the documentation correction: 31 test files passed, 8 skipped; 381 tests passed, 104 skipped; builds completed
- git diff --check passed
- no runtime code or bundle behavior changed

Related to #53. The issue should remain open until the reporter verifies the Windows GitHub-spec migration.