### PR TITLE
ci: 增加 npm 发布工作流

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,24 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      PRERELEASE: ${{ github.event.release.prerelease }}
 
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - uses: actions/setup-node@v4
+      # actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - uses: pnpm/action-setup@v4
+      # pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 11.7.0
 
@@ -41,17 +47,37 @@ jobs:
         shell: bash
         run: |
           VERSION="$(node -p "require('./package.json').version")"
-          TAG="${{ github.event.release.tag_name }}"
 
-          if [ "$TAG" != "v$VERSION" ]; then
-            echo "::error::release tag ($TAG) does not match package.json version (v$VERSION)"
+          if [ "$RELEASE_TAG" != "v$VERSION" ]; then
+            echo "::error::release tag ($RELEASE_TAG) does not match package.json version (v$VERSION)"
             exit 1
           fi
 
-          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+          if [ "$PRERELEASE" = "true" ]; then
             echo "npm_tag=next" >> "$GITHUB_OUTPUT"
           else
             echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+            # Never move the public `latest` dist-tag backwards: re-publishing
+            # a stale or recreated release would silently downgrade every
+            # exact-version pin that DSH Desktop installs (#59).
+            PUBLISHED="$(npm view @changfenhuang/dsh-genui version 2>/dev/null || true)"
+            if [ -n "$PUBLISHED" ]; then
+              BELOW="$(node -e '
+                const core = (s) => s.replace(/^v/, "").split("-")[0].split(".").map(Number);
+                const below = (t, p) => {
+                  for (let i = 0; i < Math.max(t.length, p.length); i++) {
+                    if ((t[i] ?? 0) < (p[i] ?? 0)) return true;
+                    if ((t[i] ?? 0) > (p[i] ?? 0)) return false;
+                  }
+                  return false;
+                };
+                console.log(below(core(process.argv[1]), core(process.argv[2])) ? "yes" : "no");
+              ' "v$VERSION" "$PUBLISHED")"
+              if [ "$BELOW" = "yes" ]; then
+                echo "::error::refusing to publish v$VERSION below the already-published latest ($PUBLISHED)"
+                exit 1
+              fi
+            fi
           fi
 
       # Match the existing CI environment: plugin typecheck/build resolves the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
-          cache: ''
 
       - uses: pnpm/action-setup@v4
         with:
@@ -50,9 +49,9 @@ jobs:
           fi
 
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-            echo "npm-tag=next" >> "$GITHUB_OUTPUT"
+            echo "npm_tag=next" >> "$GITHUB_OUTPUT"
           else
-            echo "npm-tag=latest" >> "$GITHUB_OUTPUT"
+            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
       # Match the existing CI environment: plugin typecheck/build resolves the
@@ -94,4 +93,4 @@ jobs:
           }
 
       - name: Publish to npm
-        run: npm publish --access public --tag "${{ steps.release.outputs.npm-tag }}"
+        run: npm publish --access public --tag "${{ steps.release.outputs.npm_tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: ''
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.7.0
+
+      # npm Trusted Publishing requires npm >= 11.5.1. Keep the release job
+      # independent from whichever npm minor happens to ship with Node 24.
+      - name: Upgrade npm for trusted publishing
+        run: npm install --global 'npm@^11.5.1'
+
+      - name: Verify release version
+        id: release
+        shell: bash
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          TAG="${{ github.event.release.tag_name }}"
+
+          if [ "$TAG" != "v$VERSION" ]; then
+            echo "::error::release tag ($TAG) does not match package.json version (v$VERSION)"
+            exit 1
+          fi
+
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            echo "npm-tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm-tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Match the existing CI environment: plugin typecheck/build resolves the
+      # DSH source tree from ../../.dsh/source/current.
+      - name: Clone DSH host
+        shell: bash
+        run: |
+          DSH_ROOT="$GITHUB_WORKSPACE/../../.dsh/source/current"
+          mkdir -p "$(dirname "$DSH_ROOT")"
+          git clone --depth 1 https://github.com/deepseek-ai/deepseek-harness.git "$DSH_ROOT"
+          git -C "$DSH_ROOT" checkout master
+          test -f "$DSH_ROOT/packages/client/ui-primitives/src/index.ts" || {
+            echo "::error::DSH host preflight failed: ui-primitives source is missing"
+            exit 1
+          }
+          echo "DSH_ROOT=$DSH_ROOT" >> "$GITHUB_ENV"
+
+      - name: Install and build DSH host
+        working-directory: ${{ github.workspace }}/../../.dsh/source/current
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run build
+
+      - name: Install plugin dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check
+        run: pnpm run check
+
+      - name: Verify package
+        run: node scripts/verify-pack.mjs
+
+      - name: Verify committed lib artifacts
+        shell: bash
+        run: |
+          git diff --exit-code -- lib/ || {
+            echo "::error::lib/ does not match src/; run pnpm run build and commit the generated artifacts"
+            exit 1
+          }
+
+      - name: Publish to npm
+        run: npm publish --access public --tag "${{ steps.release.outputs.npm-tag }}"


### PR DESCRIPTION
## 变更内容

新增 `.github/workflows/release.yml`，在 GitHub Release 发布时自动：

- 校验 tag 与 `package.json.version`；
- 复用现有 CI 环境执行 `check` 和 `verify-pack`；
- 校验 `lib/` 构建产物；
- 使用 npm Trusted Publishing / OIDC 发布到 npm；
- stable 发布到 `latest`，prerelease 发布到 `next`。

## 目的

当前 `@changfenhuang/dsh-genui` 已发布到 npm，但仓库缺少统一的 release workflow，容易造成 npm、Git tag、GitHub Release 和源码状态不同步。

这个 PR 可以把后续正式发布流程收敛到同一条流水线，减少版本漂移，并有助于解决 #59 中提到的 npm 发布与 Release 不同步问题。

## Maintainer 合并后需要配置

该 workflow 使用 npm Trusted Publishing。

需要在 npm 上为 `@changfenhuang/dsh-genui` 配置 Trusted Publisher：

- Repository：`omdsh-dev/dsh-genui`
- Workflow：`release.yml`

配置完成后无需额外保存长期 npm token。