### PR TITLE
fix: wait for complete streamed GenUI components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### 修复
+- **streaming EChart nested option**：partial parser只把已闭合的top-level `items[]`成员作为可渲染component，不再在tooltip、grid或单侧axis刚闭合时补全外层EChart；full option柱状图不会因中间缺少配对axis而触发ECharts `getAxesOnZeroOf`异常。
+
 ## [0.9.6] - 2026-08-28
 ### 兼容性
 - **dsh 0.1.2-alpha.1**：真机验收改为读取新版 Web 启动时生成的一次性令牌地址，先建立浏览器登录态，再按启动图公告的不可变组合地址检查插件资源；后台启动显式使用 `--no-open`，不再误开用户浏览器。插件运行代码和宿主配置契约无需兼容层，也未修改 dsh 本体；官方标签源码构建在 Node 24.13 下完成 macOS 真机页面激活，启动图资源返回 200。Node 24.11 会令该宿主启动图为空，验收与本机入口已固定使用 24.13。

--- a/src/client/parse-partial.ts
+++ b/src/client/parse-partial.ts
@@ -8,9 +8,10 @@
  * 1. Full parse first (the common settled case) — at most one.
  * 2. ONE left-to-right scan collects the repair candidates: every position
  *    where the prefix is bracket-balanced (trailing comma / fence tail) and
- *    every `}` object close within the depth budget (an unfinished trailing
- *    element, closed by appending the remaining brackets). The ring buffer
- *    keeps only the longest-direction candidates (≤ MAX_PARTIAL_REPAIR_ATTEMPTS),
+ *    every top-level `items[]` component close (an unfinished trailing
+ *    component is dropped by closing the root array/object). Partial candidates
+ *    must parse as a spec root; bare components wait for their own root close.
+ *    The ring buffer keeps only the longest-direction candidates (≤ MAX_PARTIAL_REPAIR_ATTEMPTS),
  *    so the work is O(n) with a hard parse-attempt cap — a pathological
  *    input can never re-scan prefixes or burn seconds in JSON.parse.
  * 3. Candidates are tried longest first; the first that parses as a GenUI
@@ -19,11 +20,10 @@
  * The result is only ever a PREFIX of the intended spec, so it is always
  * safe to render: components already present are complete and valid.
  *
- * `ponytail:` the 32-candidate / 33-parse budget is the protection ceiling
- * for depth 8 / 200 nodes; only real streaming samples proving a recovery
- * shortfall justify switching to a tokenizing parser.
+ * `ponytail:` the 32-candidate / 33-parse budget is the protection ceiling;
+ * only real streaming samples proving a recovery shortfall justify switching
+ * to a tokenizing parser.
  */
-import { GENUI_LIMITS } from './guard.ts'
 import { isGenuiSpec, type GenuiSpec } from './spec.ts'
 import { wrapSingleComponentRoot } from './spec.ts'
 
@@ -48,9 +48,9 @@ export interface PartialCandidate {
  *  (skipping strings/escapes correctly) and records:
  *  - every position where the prefix is fully balanced (trailing comma or
  *    fence tail) — candidate with an empty closing suffix;
- *  - every `}` object close whose remaining depth fits the spec budget —
- *    candidate with the remaining brackets closed (an unfinished trailing
- *    element).
+ *  - every top-level `items[]` component close — candidate with the root
+ *    array/object closed (an unfinished trailing component is dropped). Nested
+ *    object closes are not candidates because their component is still partial.
  *  Candidates are ring-buffered to the attempts budget (the LAST pushes are
  *  the longest), then returned longest-first, deduplicated by end. The scan
  *  stops at the first unbalanced close — earlier balanced prefixes remain
@@ -93,10 +93,11 @@ export function collectPartialCandidates(raw: string): { candidates: PartialCand
         // balanced prefixes recorded earlier stay valid. Stop scanning.
         break
       }
-      if (ch === '}' && stack.length <= GENUI_LIMITS.maxDepth) {
-        // A finished object element: closing the remaining brackets yields
-        // the longest legal prefix (an unfinished trailing element drops).
-        push({ end: scanned + 1, closingSuffix: closeSuffix(stack) })
+      if (ch === '}' && stack.length === 2 && stack[0] === '{' && stack[1] === '[') {
+        // Only a direct root-array member can be a finished component.
+        // Partial parsing later requires an actual spec root, so a bare
+        // component's data[] member cannot become a candidate.
+        push({ end: scanned + 1, closingSuffix: ']}' })
       }
       if (stack.length === 0) {
         // Whole prefix balanced: a complete-JSON candidate (trailing comma /
@@ -114,22 +115,15 @@ export function collectPartialCandidates(raw: string): { candidates: PartialCand
   return { candidates: deduped.slice(0, repairAttemptsLimit), scannedChars: scanned }
 }
 
-/** Closing brackets for the remaining open stack (top first). */
-function closeSuffix(stack: string[]): string {
-  let suffix = ''
-  for (let i = stack.length - 1; i >= 0; i--) suffix += stack[i] === '{' ? '}' : ']'
-  return suffix
-}
-
 /** Try to parse a candidate as a GenuiSpec. */
-function trySpec(candidate: string): GenuiSpec | null {
+function trySpec(candidate: string, allowSingleComponentRoot: boolean): GenuiSpec | null {
   try {
     const value: unknown = JSON.parse(candidate)
     if (isGenuiSpec(value)) return value
     // Single-component roots are part of the documented fence vocabulary
     // (e.g. a bare {"type":"callout",…} body) — wrap into a col so the
     // items-gated pipeline renders them (panel/append hoisted).
-    return wrapSingleComponentRoot(value)
+    return allowSingleComponentRoot ? wrapSingleComponentRoot(value) : null
   } catch {
     return null
   }
@@ -146,14 +140,14 @@ export function parsePartialGenuiSpec(raw: string): GenuiSpec | null {
   if (text === '') return null
 
   // 1. Full parse (settled / already-complete body).
-  const full = trySpec(text)
+  const full = trySpec(text, true)
   if (full !== null) return full
 
   // 2. Bounded repair: ONE forward scan, at most `repairAttemptsLimit`
   //    candidates, longest first — never a re-scan per `}`.
   const { candidates } = collectPartialCandidates(text)
   for (const candidate of candidates) {
-    const spec = trySpec(text.slice(0, candidate.end) + candidate.closingSuffix)
+    const spec = trySpec(text.slice(0, candidate.end) + candidate.closingSuffix, false)
     if (spec !== null) return spec
   }
 

--- a/tests/genui-partial.spec.tsx
+++ b/tests/genui-partial.spec.tsx
@@ -41,6 +41,25 @@ describe('parsePartialGenuiSpec', () => {
     expect((spec!.items[0] as { type: string }).type).toBe('text')
   })
 
+  it('does not expose a partial nested EChart option as a finished component', () => {
+    const first = '{"type":"text","content":"A"}'
+    const partialEchart = '{"type":"echart","option":{"tooltip":{"trigger":"axis"},"grid":{"left":48},"xAxis":{"type":"category","data":["质量指标记录"]}'
+    const spec = parsePartialGenuiSpec(`{"items":[${first},${partialEchart}`)
+
+    expect(spec?.items).toHaveLength(1)
+    expect((spec!.items[0] as { type: string }).type).toBe('text')
+  })
+
+  it('does not render a single partial EChart before its component closes', () => {
+    const partial = '{"items":[{"type":"echart","option":{"tooltip":{"trigger":"axis"},"grid":{"left":48},"xAxis":{"type":"category","data":["质量指标记录"]}'
+    expect(parsePartialGenuiSpec(partial)).toBeNull()
+  })
+
+  it('waits for a bare component root instead of treating its data item as complete', () => {
+    const partial = '{"type":"chart","data":[{"label":"A","value":1}'
+    expect(parsePartialGenuiSpec(partial)).toBeNull()
+  })
+
   it('extracts two finished components before the third', () => {
     const spec = parsePartialGenuiSpec('{"items":[{"type":"text","content":"A"},{"type":"stat","label":"B","value":"1"},{"type":"but')
     expect(spec?.items).toHaveLength(2)


### PR DESCRIPTION
## Summary

- collect partial-render candidates only when a top-level `items[]` component closes
- keep nested EChart option objects out of the render tree until their enclosing component is complete
- preserve complete bare-component roots and the bounded single-scan parser

## Reproduction

A real stock DSH DOM-channel response streamed a valid full-option bar chart in this order:

1. tooltip/grid
2. xAxis
3. yAxis
4. series

The parser previously repaired step 2 into a complete EChart and ECharts threw `getAxesOnZeroOf is not a function` because the paired yAxis had not arrived. The same final option and bundled ECharts asset pass in Chromium when applied after the complete component exists.

## Verification

- `pnpm check`
- regression coverage for a partial nested EChart option, a single partial EChart, and a bare component data item
