### PR TITLE
fix: expose bundled skill and chart contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@
 - **guard 容错升级 + validate_dsh_ui 丢弃告警（issue #42）**：table 自愈对象形态（`{title,key}` antd 风格列提取表头、`rows`/`data` 对象数组按列键展平为二维行，非标量单元格字符串化保对齐）；tabs 接受 `content` 作 `items` 别名（数组或单组件）；`countGenuiNodes` 补齐 row/col/grid/card 容器递归（此前计数偏低，掩盖丢弃）；`validate_dsh_ui` 新增声明数 vs 解析数对比（`countDeclaredGenuiNodes` + 白名单过滤，避开 file-tree `{type:'file'}` 误报），声明多于解析时返回 ❌ 并给出丢弃数量与常见原因，不再对半空树绿灯放行。
 
 ## [Unreleased]
+### 修复
+- **GenUI skill 自动进入会话目录**：Host 插件在公开 skill registry 到场时注册包内 `SKILL.md`，新会话可直接发现 `genui`，无需用户复制文件；插件卸载同步移除该 runtime skill。
+- **chart 字段错误不再静默变成柱图**：常驻 prompt 携带紧凑 `kind/data` 签名；`validate_dsh_ui` 与 `render_ui` 共同拒绝 `variant`、非法 kind、非字符串 label 和非有限数字 value，且保留未知扩展字段。
+
 ### 发布
 - npm 发布作用域改为个人账号 `@changfenhuang/dsh-genui`；GitHub 仓库继续保留在 `omdsh-dev` 组织。同步更新运行时模块标识、资源路由、安装脚本、文档和测试，不保留旧 npm 名称兼容层。
 - **正式版与测试版分流**：发布版本带预发布后缀时必须勾选 GitHub Pre-release，并只进入 npm `next`；无后缀版本只能作为正式 Release 进入 `latest`。CI 与发布验收固定覆盖 `dsh-v0.1.1-rc.2` / `dsh-v0.1.2-alpha.1`，不再跟随可变的宿主开发分支。

--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ The following is the detailed capability reference. Every behavior is constraine
 - **Accessibility**: tabs/accordions/switches/progress bars carry full ARIA and keyboard navigation (arrow keys switch tabs, Home/End jump)
 - **Zero intrusion**: without the plugin, fences are just code blocks — no errors, no session pollution
 
-Component JSON syntax: [SKILL.md](./SKILL.md) (also copyable to `~/.dsh/skills/genui/` to boost the model).
+Component JSON syntax lives in [SKILL.md](./SKILL.md). On hosts with the public skill registry, the plugin registers this bundled `genui` skill automatically, so new Sessions receive the complete component and field catalog without copying files into `~/.dsh`.
+
+`chart` stays the compact three-kind renderer: use `kind: 'bars' | 'line' | 'donut'` with finite numeric `data[].value` fields. `validate_dsh_ui` reports `variant`, unsupported kinds, and invalid datum fields explicitly; `render_ui` rejects the same errors instead of silently rendering the default bars view. Unknown extension fields remain allowed.
 
 ## 📄 Example
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -180,7 +180,9 @@ dsh plugin --profile web add link:$PWD
 - **探索成就**：同一 dock 的「成就」按钮——12 个成就（初次相见 → 蓝图之魂），按渲染/交互/面板/模板埋点计数，解锁弹 toast，成就页由 `dsh-ui` 渲染自己的列表；只存计数（localStorage），绝不读取消息内容；隐藏成就（传说）解锁前显示「？」。
 - **首次提示**：第一块面板出现时显示 6 秒一次性提示（指向「模板」按钮），不打扰式引导。
 
-组件 JSON 语法见 [SKILL.md](./SKILL.md)（也可复制到 `~/.dsh/skills/genui/` 增强模型使用）。
+组件 JSON 语法见 [SKILL.md](./SKILL.md)。宿主提供公开 skill registry 时，插件会自动注册内置 `genui` skill，因此新会话无需向 `~/.dsh` 复制文件即可获得完整组件与字段目录。
+
+`chart` 保持三种图形的紧凑渲染器：使用 `kind: 'bars' | 'line' | 'donut'`，且 `data[].value` 必须是有限数字。`validate_dsh_ui` 会明确报告误用的 `variant`、不支持的 kind 和非法数据字段；`render_ui` 对同样错误直接失败，不再静默渲染默认柱图。未知扩展字段仍允许存在。
 
 ## 📄 示例
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -15,7 +15,7 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 
 布局：`text` `row` `col` `grid` `card` `divider` `spacer`
 展示：`stat` `badge` `progress` `list` `table` `keyvalue` `avatar` `image` `audio` `video` `timeline` `file-tree` `breadcrumb` `diff` `json` `code` `callout` `steps`
-图表：`chart`（bars/line/donut，可多序列）`plot`（数学函数图）`echart`（ECharts 全功能图表）交互：`button` `input` `select` `checkbox` `radio` `switch` `textarea` `tabs` `accordion` `copy`
+图表：`chart`（bars/line/donut，可多序列）`plot`（数学函数图）`echart`（ECharts 全功能图表）
 交互：`button` `input` `select` `checkbox` `radio` `switch` `textarea` `tabs` `accordion` `copy`
 
 ### 布局

--- a/src/client/blocks/charts.tsx
+++ b/src/client/blocks/charts.tsx
@@ -138,7 +138,7 @@ export const BarsNode = memo(function BarsNode({ chart }: { chart: GenuiChart })
     const labels = grouped[0]!.data.map(d => d.label)
     const max = Math.max(...grouped.flatMap(s => s.data.map(d => Number(d.value) || 0)), 1)
     return (
-      <div className={css.chart}>
+      <div className={css.chart} data-genui-chart="bars">
         <div className={css.chartPlot}>
           {[0, 25, 50, 75].map(p => (
             <span key={p} className={p === 0 ? css.baseline : css.gridline} style={{ bottom: `${p}%` }} />
@@ -181,7 +181,7 @@ export const BarsNode = memo(function BarsNode({ chart }: { chart: GenuiChart })
   // and used to collapse the bar entirely.
   const max = Math.max(...data.map(d => Number(d.value) || 0), 1)
   return (
-    <div className={css.chart}>
+    <div className={css.chart} data-genui-chart="bars">
       <div className={css.chartPlot}>
         {[0, 25, 50, 75].map(p => (
           <span key={p} className={p === 0 ? css.baseline : css.gridline} style={{ bottom: `${p}%` }} />
@@ -233,7 +233,7 @@ export const LineChartNode = memo(function LineChartNode({ chart }: { chart: Gen
     return t.toFixed(1)
   }
   return (
-    <div className={css.lineChart}>
+    <div className={css.lineChart} data-genui-chart="line">
       <svg width="100%" viewBox={`0 0 ${W} ${H}`}>
         {ticks.map((t, i) => {
           const y = padT + (1 - (t - min) / span) * (H - padT - padB)
@@ -277,7 +277,7 @@ export const DonutNode = memo(function DonutNode({ chart }: { chart: GenuiChart 
   const C = 2 * Math.PI * R
   let offset = 0
   return (
-    <div className={css.donut}>
+    <div className={css.donut} data-genui-chart="donut">
       <svg width="120" height="120" viewBox="0 0 120 120">
         <circle cx="60" cy="60" r={R} fill="none" strokeWidth="14" className={css.donutTrack} />
         {clamped.map((d, i) => {

--- a/src/client/fence-render.tsx
+++ b/src/client/fence-render.tsx
@@ -24,6 +24,7 @@ import { parsePartialGenuiSpec } from './parse-partial.ts'
 import { applyPanelOperation, diagnosePanelBudget, type PanelOperationStatus } from './panel-store.ts'
 import type { GenuiSpec } from './spec.ts'
 import { completeFenceJson, describeJsonFailure, isCompleteJson, repairFenceJson } from '../shared/fence-repair.ts'
+import { validateRenderableChartSemantics } from '../plugin/chart-contract.ts'
 
 /** Settled fence source identity (data shape, host-independent). */
 export interface GenuiFenceSource {
@@ -53,6 +54,14 @@ const FENCE_ERROR_STYLE: CSSProperties = {
   whiteSpace: 'pre-wrap',
 }
 
+/** Return a chart-semantic diagnostic for parseable raw fence content. */
+function chartSemanticFailure(raw: string): string | null {
+  const parsed = parsePartialGenuiSpec(raw)
+  if (parsed === null) return null
+  const errors = validateRenderableChartSemantics(parsed)
+  return errors.length === 0 ? null : errors.join('；')
+}
+
 /**
  * Fallback for a ```dsh-ui fence whose body has no finished component yet.
  * Two very different situations land here and they must not be conflated:
@@ -64,11 +73,11 @@ const FENCE_ERROR_STYLE: CSSProperties = {
  *    correct rendering (partial JSON must never look like an error).
  *
  * 2. **Settled defect** — the message is finished but the body still does
- *    not parse as JSON (a malformed fence like a missing `}`). This used to
- *    fail silently: the fence degraded to a code block with no hint, and the
- *    author had no way to know the UI never rendered. Once the streaming
- *    marker is gone, surface a compact diagnostic with the parse position so
- *    the defect is visible instead of silent.
+ *    not parse as JSON (a malformed fence like a missing `}`) or violates the
+ *    native chart contract. This used to fail silently: the fence degraded to
+ *    a code block with no hint, and the author had no way to know the UI never
+ *    rendered. Once the streaming marker is gone, surface a compact diagnostic
+ *    so the defect is visible instead of silent.
  */
 function FenceFallback({ raw, fenceKey }: { raw: string; fenceKey: Key }) {
   const ref = useRef<HTMLDivElement | null>(null)
@@ -77,12 +86,18 @@ function FenceFallback({ raw, fenceKey }: { raw: string; fenceKey: Key }) {
     const node = ref.current
     if (node !== null && node.closest('[data-streaming]') === null) setSettled(true)
   })
-  const diagnostic = settled && raw.trim() !== '' ? describeJsonFailure(raw) : null
+  const chartDiagnostic = settled ? chartSemanticFailure(raw) : null
+  const parseDiagnostic = settled && chartDiagnostic === null && raw.trim() !== '' ? describeJsonFailure(raw) : null
   return (
     <div ref={ref}>
-      {diagnostic !== null && (
+      {chartDiagnostic !== null && (
         <div style={FENCE_ERROR_STYLE} role="alert">
-          ⚠️ dsh-ui fence JSON 解析失败{diagnostic} —— 围栏保持为代码块；请让模型检查并修复 JSON 后重发。
+          ⚠️ dsh-ui chart 字段验证失败：{chartDiagnostic} —— 围栏保持为代码块；请修正 chart 字段后重发。
+        </div>
+      )}
+      {chartDiagnostic === null && parseDiagnostic !== null && (
+        <div style={FENCE_ERROR_STYLE} role="alert">
+          ⚠️ dsh-ui fence JSON 解析失败{parseDiagnostic} —— 围栏保持为代码块；请让模型检查并修复 JSON 后重发。
         </div>
       )}
       <CodeBlock key={fenceKey} code={`${raw}\n`} lang="dsh-ui" />
@@ -115,6 +130,12 @@ function FencePanelPublisher({ sessionId, sourceId, order, spec }: {
   return null
 }
 
+/** Repair one parsed value only when its native charts are actually renderable. */
+function repairRenderableSpec(value: unknown): GenuiSpec | null {
+  if (validateRenderableChartSemantics(value).length > 0) return null
+  return repairGenuiSpec(value)
+}
+
 /**
  * Resolve a raw fence body to a guarded spec.
  *
@@ -124,21 +145,24 @@ function FencePanelPublisher({ sessionId, sourceId, order, spec }: {
  * - Tier-2 completion (missing quotes/brackets): settled renders only —
  *   `context.source` exists exclusively once the message finished, so
  *   streaming halves are never completed early.
+ * - Native chart semantics are checked before repair on every candidate so
+ *   aliases, empty collections, or line/donut series cannot repair into a
+ *   default/blank chart.
  */
 export function resolveGenuiSpec(raw: string, context?: GenuiFenceContext): GenuiSpec | null {
   const parsed = parsePartialGenuiSpec(raw)
-  let spec = parsed === null ? null : repairGenuiSpec(parsed)
+  let spec = parsed === null ? null : repairRenderableSpec(parsed)
   if (spec === null) {
     const repaired = repairFenceJson(raw)
     if (repaired !== null) {
       const reparsed = parsePartialGenuiSpec(repaired.text)
-      spec = reparsed === null ? null : repairGenuiSpec(reparsed)
+      spec = reparsed === null ? null : repairRenderableSpec(reparsed)
     }
     if (spec === null && context?.source !== undefined) {
       const completed = completeFenceJson(raw)
       if (completed !== null) {
         const reparsed = parsePartialGenuiSpec(completed.text)
-        spec = reparsed === null ? null : repairGenuiSpec(reparsed)
+        spec = reparsed === null ? null : repairRenderableSpec(reparsed)
       }
     }
   }

--- a/src/client/guard.ts
+++ b/src/client/guard.ts
@@ -1194,52 +1194,87 @@ export const GENUI_NODE_TYPES: ReadonlySet<string> = new Set([
 ])
 
 /**
- * Count DECLARED nodes in a raw spec tree: objects whose `type` is a
+ * Visit and count declared nodes in a raw spec tree: objects whose `type` is a
  * white-listed string, descending the same containers `countGenuiNodes`
- * walks. `validate_dsh_ui` compares this with the repaired count to surface
- * children the repair silently dropped (blank-render class of bugs, issue
- * #42) instead of reporting a green check on a half-empty tree.
+ * walks. Callers can inspect field semantics or compare the count with the
+ * repaired tree without maintaining another traversal.
  */
-export function countDeclaredGenuiNodes(value: unknown, cap = Number.POSITIVE_INFINITY): number {
+function visitDeclaredGenuiNodes(
+  value: unknown,
+  cap: number,
+  visit: (node: Record<string, unknown>, at: string) => void,
+): number {
   let count = 0
   const declared = (candidate: unknown): boolean => {
     const o = obj(candidate)
     return o !== undefined && typeof o.type === 'string' && GENUI_NODE_TYPES.has(o.type)
   }
-  const walk = (list: unknown): void => {
+  function walk(list: unknown, path: string): void {
     if (!Array.isArray(list)) return
-    for (const item of list) {
+    for (let index = 0; index < list.length; index++) {
+      walkNode(list[index], `${path}[${index}]`)
       if (count >= cap) return
-      if (!declared(item)) continue
-      count += 1
-      const v = obj(item)
-      if (v === undefined) continue
-      if (v.type === 'tabs' && Array.isArray(v.tabs)) {
-        for (const t of v.tabs) walkItemsOf(t)
-      } else if (v.type === 'accordion' && Array.isArray(v.items)) {
-        for (const it of v.items) walkItemsOf(it)
-      } else if ((v.type === 'row' || v.type === 'col' || v.type === 'grid' || v.type === 'card') && Array.isArray(v.items)) {
-        walk(v.items)
-      } else if (v.type === 'list' && Array.isArray(v.items)) {
-        for (const li of v.items) {
-          if (declared(li)) walk([li])
-        }
+    }
+  }
+  function walkNode(item: unknown, at: string): void {
+    if (count >= cap || !declared(item)) return
+    const v = obj(item)
+    if (v === undefined) return
+    count += 1
+    visit(v, at)
+    if (v.type === 'tabs' && Array.isArray(v.tabs)) {
+      for (let tab = 0; tab < v.tabs.length; tab++) {
+        walkItemsOf(v.tabs[tab], `${at}.tabs[${tab}]`)
+      }
+    } else if (v.type === 'accordion' && Array.isArray(v.items)) {
+      for (let row = 0; row < v.items.length; row++) {
+        walkItemsOf(v.items[row], `${at}.items[${row}]`)
+      }
+    } else if ((v.type === 'row' || v.type === 'col' || v.type === 'grid' || v.type === 'card') && Array.isArray(v.items)) {
+      walk(v.items, `${at}.items`)
+    } else if (v.type === 'list' && Array.isArray(v.items)) {
+      for (let row = 0; row < v.items.length; row++) {
+        walkNode(v.items[row], `${at}.items[${row}]`)
       }
     }
   }
-  const walkItemsOf = (holder: unknown): void => {
+  function walkItemsOf(holder: unknown, path: string): void {
     const o = obj(holder)
     if (o === undefined) return
     const items = o.items !== undefined ? o.items : o.content
-    if (Array.isArray(items)) walk(items)
-    else if (declared(items)) walk([items])
+    if (Array.isArray(items)) walk(items, `${path}.items`)
+    else walkNode(items, `${path}.items`)
   }
   const root = obj(value)
   if (root === undefined) return count
   // Single-component root (no items array): the root itself is the declared node.
-  if (!Array.isArray(root.items) && declared(value)) walk([value])
-  else walk(root.items)
+  if (!Array.isArray(root.items) && declared(value)) walkNode(value, 'spec')
+  else walk(root.items, 'items')
   return count
+}
+
+/**
+ * Count white-listed nodes declared by a raw spec before repair drops invalid entries.
+ * @param value - raw GenUI spec.
+ * @param cap - traversal ceiling.
+ * @returns declared node count up to the ceiling.
+ */
+export function countDeclaredGenuiNodes(value: unknown, cap = Number.POSITIVE_INFINITY): number {
+  return visitDeclaredGenuiNodes(value, cap, () => {})
+}
+
+/**
+ * Return field-level chart errors without changing other repairable component families.
+ * @param value - raw GenUI spec.
+ * @returns chart semantic errors in tree order.
+ */
+export function validateGenuiChartSemantics(value: unknown): string[] {
+  const errors: string[] = []
+  visitDeclaredGenuiNodes(value, GENUI_LIMITS.maxNodes + 1, (node, at) => {
+    if (node.type !== 'chart') return
+    validateChartNode(node, at, errors)
+  })
+  return errors
 }
 
 /**
@@ -1288,6 +1323,59 @@ export function validateGenuiSpec(value: unknown): GenuiValidation {
 }
 
 type Walker = (list: unknown, depth: number, path: string) => void
+
+function validateChartData(value: unknown, at: string, errors: string[]): void {
+  if (!Array.isArray(value)) return
+  for (let index = 0; index < value.length; index++) {
+    const datum = obj(value[index])
+    const path = `${at}[${index}]`
+    if (datum === undefined) {
+      errors.push(`${path} must be an object`)
+      continue
+    }
+    if (typeof datum.label !== 'string') errors.push(`${path}.label must be a string`)
+    if (typeof datum.value !== 'number' || !Number.isFinite(datum.value)) {
+      errors.push(`${path}.value must be a finite number`)
+    }
+    if (datum.color !== undefined && typeof datum.color !== 'string') {
+      errors.push(`${path}.color must be a string`)
+    }
+  }
+}
+
+function validateChartSeries(value: unknown, at: string, errors: string[]): void {
+  if (!Array.isArray(value)) return
+  for (let index = 0; index < value.length; index++) {
+    const series = obj(value[index])
+    const path = `${at}[${index}]`
+    if (series === undefined) {
+      errors.push(`${path} must be an object`)
+      continue
+    }
+    if (typeof series.label !== 'string') errors.push(`${path}.label must be a string`)
+    if (series.color !== undefined && typeof series.color !== 'string') {
+      errors.push(`${path}.color must be a string`)
+    }
+    if (!Array.isArray(series.data)) errors.push(`${path}.data must be an array`)
+    validateChartData(series.data, `${path}.data`, errors)
+  }
+}
+
+function validateChartNode(v: Record<string, unknown>, at: string, errors: string[]): void {
+  if (!Array.isArray(v.data) && !Array.isArray(v.series)) {
+    errors.push(`${at}: type 'chart' requires data or series (array)`)
+  }
+  if (v.variant !== undefined) errors.push(`${at}.variant is unsupported; use kind`)
+  if (v.data !== undefined && !Array.isArray(v.data)) errors.push(`${at}.data must be an array`)
+  if (v.series !== undefined && !Array.isArray(v.series)) errors.push(`${at}.series must be an array`)
+  if (v.kind !== undefined
+    && (typeof v.kind !== 'string'
+      || !CHART_KINDS.includes(v.kind as typeof CHART_KINDS[number]))) {
+    errors.push(`${at}.kind must be bars, line, or donut`)
+  }
+  validateChartData(v.data, `${at}.data`, errors)
+  validateChartSeries(v.series, `${at}.series`, errors)
+}
 
 function validateNode(value: unknown, depth: number, at: string, errors: string[], walk: Walker): void {
   if (depth > GENUI_LIMITS.maxDepth) {
@@ -1386,7 +1474,7 @@ function validateNode(value: unknown, depth: number, at: string, errors: string[
       if (!Array.isArray(v.rows)) errors.push(`${at}: type 'table' requires rows (array)`)
       break
     case 'chart':
-      if (!Array.isArray(v.data) && !Array.isArray(v.series)) errors.push(`${at}: type 'chart' requires data or series (array)`)
+      validateChartNode(v, at, errors)
       break
     case 'tabs': {
       if (!Array.isArray(v.tabs)) errors.push(`${at}: type 'tabs' requires tabs (array)`)

--- a/src/plugin/chart-contract.ts
+++ b/src/plugin/chart-contract.ts
@@ -1,0 +1,103 @@
+import { validateGenuiChartSemantics } from '../client/guard.ts'
+
+/** Plain object helper for raw model-authored specs. */
+function obj(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+}
+
+/**
+ * Visit chart nodes through the component-bearing containers understood by
+ * the GenUI guard. This deliberately does not recursively inspect arbitrary
+ * objects (for example `json.value` or `echart.option`), where a nested
+ * `{type:"chart"}` is data rather than a GenUI node.
+ */
+function visitChartNodes(
+  value: unknown,
+  visit: (node: Record<string, unknown>, at: string) => void,
+): void {
+  function walkNode(value: unknown, at: string): void {
+    const node = obj(value)
+    if (node === undefined || typeof node.type !== 'string') return
+    if (node.type === 'chart') visit(node, at)
+
+    if ((node.type === 'row' || node.type === 'col' || node.type === 'grid' || node.type === 'card') && Array.isArray(node.items)) {
+      walk(node.items, `${at}.items`)
+      return
+    }
+    if (node.type === 'tabs' && Array.isArray(node.tabs)) {
+      for (let index = 0; index < node.tabs.length; index++) {
+        const tab = obj(node.tabs[index])
+        if (tab === undefined) continue
+        const items = tab.items !== undefined ? tab.items : tab.content
+        if (Array.isArray(items)) walk(items, `${at}.tabs[${index}].items`)
+        else walkNode(items, `${at}.tabs[${index}].items`)
+      }
+      return
+    }
+    if (node.type === 'accordion' && Array.isArray(node.items)) {
+      for (let index = 0; index < node.items.length; index++) {
+        const item = obj(node.items[index])
+        if (item === undefined) continue
+        const items = item.items !== undefined ? item.items : item.content
+        if (Array.isArray(items)) walk(items, `${at}.items[${index}].items`)
+        else walkNode(items, `${at}.items[${index}].items`)
+      }
+      return
+    }
+    if (node.type === 'list' && Array.isArray(node.items)) {
+      for (let index = 0; index < node.items.length; index++) {
+        walkNode(node.items[index], `${at}.items[${index}]`)
+      }
+    }
+  }
+
+  function walk(list: unknown, path: string): void {
+    if (!Array.isArray(list)) return
+    for (let index = 0; index < list.length; index++) {
+      walkNode(list[index], `${path}[${index}]`)
+    }
+  }
+
+  const root = obj(value)
+  if (root === undefined) return
+  if (!Array.isArray(root.items) && root.type === 'chart') walkNode(root, 'spec')
+  else walk(root.items, 'items')
+}
+
+/**
+ * Validate the native chart contract all the way to something the renderer
+ * can actually draw. The shared guard still owns field/type validation; this
+ * layer adds renderer-specific invariants that would otherwise produce an
+ * empty line/donut chart or a grouped-bars shell with no points.
+ */
+export function validateRenderableChartSemantics(value: unknown): string[] {
+  const errors = validateGenuiChartSemantics(value)
+  visitChartNodes(value, (node, at) => {
+    const kind = node.kind === undefined ? 'bars' : node.kind
+
+    if (Array.isArray(node.data) && node.data.length === 0) {
+      errors.push(`${at}.data must not be empty`)
+    }
+    if (Array.isArray(node.series)) {
+      if (node.series.length === 0) errors.push(`${at}.series must not be empty`)
+      for (let index = 0; index < node.series.length; index++) {
+        const series = obj(node.series[index])
+        if (series !== undefined && Array.isArray(series.data) && series.data.length === 0) {
+          errors.push(`${at}.series[${index}].data must not be empty`)
+        }
+      }
+    }
+
+    if (kind === 'line' || kind === 'donut') {
+      if (node.series !== undefined) {
+        errors.push(`${at}.series is only supported for bars`)
+      }
+      if (node.data === undefined) {
+        errors.push(`${at}.data is required for ${kind}`)
+      }
+    }
+  })
+  return errors
+}

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -14,8 +14,9 @@ import { Context } from '@deepseek-ai/cordis'
 import type {} from '@deepseek-ai/dsh-system-prompt'
 import type {} from '@deepseek-ai/dsh-tools'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { createRenderUiTool, createValidateDshUiTool } from './tool.ts'
 
@@ -98,7 +99,7 @@ The spec is a white-listed component tree rendered inline where the fence sits. 
 
 - 布局: text · row · col · grid · card · divider · spacer
 - 展示: badge · stat · progress · list · table · keyvalue · avatar · audio · video · timeline · file-tree · breadcrumb · callout · steps · diff · json · code · copy
-- 图表: chart (bars|line|donut) · echart (preset|option) · plot (函数图)
+- 图表: chart {"type":"chart","kind":"bars|line|donut","data":[{"label":"...","value":n,"color":"#hex?"}],"series":[...]?} · echart (preset|option) · plot (函数图)
 - 交互: button · input · textarea · select · checkbox · switch · slider · radio · submit · quiz · link · tabs · accordion
 - 高级: mermaid (flowchart/sequence/class/gantt/pie/er/state/journey) · diagram (编辑级架构/流程图，27 种 kind) · scene3d (3D WebGL)
 
@@ -122,6 +123,40 @@ Rules:
 // inject entries are hard requirements, so the registry is probed at runtime
 // instead (see apply).
 export const inject = ['systemPrompt']
+
+type BundledSkill = {
+  name: string
+  description: string
+  source: 'bundled'
+  provider: string
+  path: string
+  resourceBase: { kind: 'directory'; path: string }
+  content: string
+}
+
+type SkillRegistry = {
+  register(skill: BundledSkill): () => void
+}
+
+/** Load the packaged skill from both source and built module locations. */
+function bundledSkill(): BundledSkill {
+  const moduleDirectory = dirname(fileURLToPath(new URL(import.meta.url)))
+  const path = basename(moduleDirectory) === 'plugin'
+    ? resolve(moduleDirectory, '../../SKILL.md')
+    : resolve(moduleDirectory, '../SKILL.md')
+  const raw = readFileSync(path, 'utf8')
+  const end = raw.indexOf('\n---\n', 4)
+  if (!raw.startsWith('---\n') || end < 0) throw new Error('genui SKILL.md has invalid frontmatter')
+  return {
+    name: 'genui',
+    description: 'GenUI 完整组件与字段规范，用于生成 dsh-ui 结构化交互界面。',
+    source: 'bundled',
+    provider: '@changfenhuang/dsh-genui',
+    path,
+    resourceBase: { kind: 'directory', path: dirname(path) },
+    content: raw.slice(end + 5),
+  }
+}
 
 export function apply(ctx: Context): void {
   ctx.systemPrompt.section({
@@ -154,6 +189,11 @@ export function apply(ctx: Context): void {
   tryRegister(undefined)
   ctx.on('internal/service', (name: string, value: unknown) => {
     if (name === 'tools') tryRegister(value as { register(tool: unknown): unknown })
+  })
+
+  ctx.inject(['skills'], (skillCtx) => {
+    const skills = (skillCtx as Context & { skills: SkillRegistry }).skills
+    skills.register(bundledSkill())
   })
 
   // Lazy-engine asset route: same optional-probe pattern as the tools

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -99,7 +99,7 @@ The spec is a white-listed component tree rendered inline where the fence sits. 
 
 - 布局: text · row · col · grid · card · divider · spacer
 - 展示: badge · stat · progress · list · table · keyvalue · avatar · audio · video · timeline · file-tree · breadcrumb · callout · steps · diff · json · code · copy
-- 图表: chart {"type":"chart","kind":"bars|line|donut","data":[{"label":"...","value":n,"color":"#hex?"}],"series":[...]?} · echart (preset|option) · plot (函数图)
+- 图表: chart {"type":"chart","kind":"bars|line|donut","data":[{"label":"...","value":n,"color":"#hex?"}],"series":[...]?}（series 仅 bars；未知扩展字段可通过校验，但原生 chart repair/render 会忽略） · echart (preset|option) · plot (函数图)
 - 交互: button · input · textarea · select · checkbox · switch · slider · radio · submit · quiz · link · tabs · accordion
 - 高级: mermaid (flowchart/sequence/class/gantt/pie/er/state/journey) · diagram (编辑级架构/流程图，27 种 kind) · scene3d (3D WebGL)
 
@@ -124,6 +124,10 @@ Rules:
 // instead (see apply).
 export const inject = ['systemPrompt']
 
+const BUNDLED_SKILL_RANK = 600
+const BUNDLED_SKILL_PROVIDER = 'dsh-genui'
+const BUNDLED_SKILL_DESCRIPTION = 'GenUI 完整组件与字段规范，用于生成 dsh-ui 结构化交互界面。'
+
 type BundledSkill = {
   name: string
   description: string
@@ -134,11 +138,22 @@ type BundledSkill = {
   content: string
 }
 
-type SkillRegistry = {
-  register(skill: BundledSkill): () => void
+type BundledSkillCandidate = Omit<BundledSkill, 'content'> & {
+  rank: number
+  locator: string
 }
 
-/** Load the packaged skill from both source and built module locations. */
+type BundledSkillProvider = {
+  name: string
+  list(): Promise<BundledSkillCandidate[]>
+  get(candidate: BundledSkillCandidate): Promise<BundledSkill>
+}
+
+type SkillRegistry = {
+  registerProvider(create: () => BundledSkillProvider): () => void
+}
+
+/** Resolve the packaged skill from both source and built module locations. */
 function bundledSkill(): BundledSkill {
   const moduleDirectory = dirname(fileURLToPath(new URL(import.meta.url)))
   const path = basename(moduleDirectory) === 'plugin'
@@ -149,12 +164,32 @@ function bundledSkill(): BundledSkill {
   if (!raw.startsWith('---\n') || end < 0) throw new Error('genui SKILL.md has invalid frontmatter')
   return {
     name: 'genui',
-    description: 'GenUI 完整组件与字段规范，用于生成 dsh-ui 结构化交互界面。',
+    description: BUNDLED_SKILL_DESCRIPTION,
     source: 'bundled',
-    provider: '@changfenhuang/dsh-genui',
+    provider: BUNDLED_SKILL_PROVIDER,
     path,
     resourceBase: { kind: 'directory', path: dirname(path) },
     content: raw.slice(end + 5),
+  }
+}
+
+/** Register through the provider path so source=bundled also gets bundled precedence. */
+function bundledSkillProvider(): BundledSkillProvider {
+  const skill = bundledSkill()
+  const candidate: BundledSkillCandidate = {
+    name: skill.name,
+    description: skill.description,
+    source: skill.source,
+    provider: skill.provider,
+    path: skill.path,
+    resourceBase: skill.resourceBase,
+    rank: BUNDLED_SKILL_RANK,
+    locator: skill.path,
+  }
+  return {
+    name: BUNDLED_SKILL_PROVIDER,
+    list: () => Promise.resolve([candidate]),
+    get: () => Promise.resolve(skill),
   }
 }
 
@@ -193,7 +228,7 @@ export function apply(ctx: Context): void {
 
   ctx.inject(['skills'], (skillCtx) => {
     const skills = (skillCtx as Context & { skills: SkillRegistry }).skills
-    skills.register(bundledSkill())
+    skills.registerProvider(() => bundledSkillProvider())
   })
 
   // Lazy-engine asset route: same optional-probe pattern as the tools

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -127,10 +127,12 @@ export const inject = ['systemPrompt']
 const BUNDLED_SKILL_RANK = 600
 const BUNDLED_SKILL_PROVIDER = 'dsh-genui'
 const BUNDLED_SKILL_DESCRIPTION = 'GenUI 完整组件与字段规范，用于生成 dsh-ui 结构化交互界面。'
+const BUNDLED_SKILL_INVOCATION = { modelInvocable: true, userInvocable: true } as const
 
 type BundledSkill = {
   name: string
   description: string
+  invocation: typeof BUNDLED_SKILL_INVOCATION
   source: 'bundled'
   provider: string
   path: string
@@ -165,6 +167,7 @@ function bundledSkill(): BundledSkill {
   return {
     name: 'genui',
     description: BUNDLED_SKILL_DESCRIPTION,
+    invocation: BUNDLED_SKILL_INVOCATION,
     source: 'bundled',
     provider: BUNDLED_SKILL_PROVIDER,
     path,
@@ -179,6 +182,7 @@ function bundledSkillProvider(): BundledSkillProvider {
   const candidate: BundledSkillCandidate = {
     name: skill.name,
     description: skill.description,
+    invocation: skill.invocation,
     source: skill.source,
     provider: skill.provider,
     path: skill.path,

--- a/src/plugin/tool.ts
+++ b/src/plugin/tool.ts
@@ -24,9 +24,9 @@ import type { GenericCallView, GenericResultView, JsonSchemaNode, ToolDefinition
 import type { GenuiSpec } from '../client/spec.ts'
 import {
   GENUI_LIMITS, countDeclaredGenuiNodes, countGenuiNodes, repairGenuiSpec,
-  validateGenuiChartSemantics,
 } from '../client/guard.ts'
 import { completeFenceJson } from '../shared/fence-repair.ts'
+import { validateRenderableChartSemantics } from './chart-contract.ts'
 
 /**
  * Arguments schema: an open `spec` slot. The schema must NOT reject anything
@@ -176,7 +176,7 @@ export function createRenderUiTool(): ToolDefinition {
     },
     async execute(args: unknown): Promise<JsonValue> {
       const input = specOf(args)
-      const chartErrors = validateGenuiChartSemantics(input)
+      const chartErrors = validateRenderableChartSemantics(input)
       if (chartErrors.length > 0) {
         throw new Error('render_ui spec invalid: ' + chartErrors.join('; '))
       }
@@ -287,7 +287,7 @@ const COMMON_CAUSES =
 
 /** Return the model-facing chart field failure for one parsed fence body. */
 function chartValidationFailure(value: unknown): string | undefined {
-  const errors = validateGenuiChartSemantics(value)
+  const errors = validateRenderableChartSemantics(value)
   return errors.length === 0 ? undefined : `❌ chart 字段验证失败：\n- ${errors.join('\n- ')}`
 }
 

--- a/src/plugin/tool.ts
+++ b/src/plugin/tool.ts
@@ -22,7 +22,10 @@ import type { ContentBlock } from '@deepseek-ai/dsh-llm'
 import type { JsonValue } from '@deepseek-ai/dsh-session'
 import type { GenericCallView, GenericResultView, JsonSchemaNode, ToolDefinition } from '@deepseek-ai/dsh-tools'
 import type { GenuiSpec } from '../client/spec.ts'
-import { GENUI_LIMITS, countDeclaredGenuiNodes, countGenuiNodes, repairGenuiSpec } from '../client/guard.ts'
+import {
+  GENUI_LIMITS, countDeclaredGenuiNodes, countGenuiNodes, repairGenuiSpec,
+  validateGenuiChartSemantics,
+} from '../client/guard.ts'
 import { completeFenceJson } from '../shared/fence-repair.ts'
 
 /**
@@ -172,7 +175,12 @@ export function createRenderUiTool(): ToolDefinition {
       },
     },
     async execute(args: unknown): Promise<JsonValue> {
-      const spec = repairGenuiSpec(specOf(args))
+      const input = specOf(args)
+      const chartErrors = validateGenuiChartSemantics(input)
+      if (chartErrors.length > 0) {
+        throw new Error('render_ui spec invalid: ' + chartErrors.join('; '))
+      }
+      const spec = repairGenuiSpec(input)
       if (spec === null) {
         return 'render_ui：spec 无效 —— 根对象需要 "items" 数组（组件树白名单见系统提示词），请修正后重试。'
       }
@@ -277,6 +285,12 @@ function bracketDiagnostic(raw: string): string {
 const COMMON_CAUSES =
   '常见原因：① 收尾括号错位/缺失（{ 与 }、[ 与 ] 数量不相等）② 字符串值内用了半角引号 "（中文引语请用 “” 或 「」）③ 尾随逗号 ④ 字符串未闭合'
 
+/** Return the model-facing chart field failure for one parsed fence body. */
+function chartValidationFailure(value: unknown): string | undefined {
+  const errors = validateGenuiChartSemantics(value)
+  return errors.length === 0 ? undefined : `❌ chart 字段验证失败：\n- ${errors.join('\n- ')}`
+}
+
 /** Build the validate_dsh_ui tool definition (registered alongside render_ui). */
 export function createValidateDshUiTool(): ToolDefinition {
   return {
@@ -304,11 +318,18 @@ export function createValidateDshUiTool(): ToolDefinition {
         // FIXED JSON instead of asking it to re-author the fix — re-writing
         // the whole fence by hand is where the next typo comes from.
         const repaired = completeFenceJson(raw)
-        if (repaired !== null && repairGenuiSpec(JSON.parse(repaired.text) as unknown) !== null) {
-          return `❌ dsh-ui 围栏 JSON 解析失败：${detail}。\n${bracketDiagnostic(raw)}  已自动修复 ${repaired.repairs} 处，下面是修复后的 JSON，直接作为围栏正文发出即可（无需再验证）：\n\`\`\`\n${repaired.text}\n\`\`\``
+        if (repaired !== null) {
+          const repairedValue = JSON.parse(repaired.text) as unknown
+          const chartFailure = chartValidationFailure(repairedValue)
+          if (chartFailure !== undefined) return chartFailure
+          if (repairGenuiSpec(repairedValue) !== null) {
+            return `❌ dsh-ui 围栏 JSON 解析失败：${detail}。\n${bracketDiagnostic(raw)}  已自动修复 ${repaired.repairs} 处，下面是修复后的 JSON，直接作为围栏正文发出即可（无需再验证）：\n\`\`\`\n${repaired.text}\n\`\`\``
+          }
         }
         return `❌ dsh-ui 围栏 JSON 解析失败：${detail}。\n${bracketDiagnostic(raw)}  自动修复未能恢复（结构损坏），请按错误信息修正后重新调用本工具验证，通过后再发出围栏。\n${COMMON_CAUSES}`
       }
+      const chartFailure = chartValidationFailure(parsed)
+      if (chartFailure !== undefined) return chartFailure
       const spec = repairGenuiSpec(parsed)
       if (spec === null) {
         return '❌ 不是合法 GenUI spec：根对象需要 "items" 数组，且每个节点 type 必须在白名单内（见系统提示词）。请修正后重新验证。'

--- a/tests/genui-chart-contract.spec.tsx
+++ b/tests/genui-chart-contract.spec.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { renderGenuiFence, resolveGenuiSpec } from '../src/client/fence-render.tsx'
+
+afterEach(cleanup)
+
+describe('native chart renderability contract', () => {
+  it('rejects series-only line charts on the direct fence path', () => {
+    const raw = JSON.stringify({
+      items: [{
+        type: 'chart',
+        kind: 'line',
+        series: [{ label: 'A', data: [{ label: '周一', value: 128 }] }],
+      }],
+    })
+    expect(resolveGenuiSpec(raw)).toBeNull()
+
+    render(<div>{renderGenuiFence(raw, 'line-series')}</div>)
+    const alert = screen.getByRole('alert')
+    expect(alert.textContent).toContain('chart 字段验证失败')
+    expect(alert.textContent).toContain('series is only supported for bars')
+    expect(alert.textContent).toContain('data is required for line')
+  })
+
+  it('rejects empty chart collections before they can render blank', () => {
+    expect(resolveGenuiSpec(JSON.stringify({
+      items: [{ type: 'chart', data: [] }],
+    }))).toBeNull()
+
+    expect(resolveGenuiSpec(JSON.stringify({
+      items: [{ type: 'chart', series: [] }],
+    }))).toBeNull()
+
+    expect(resolveGenuiSpec(JSON.stringify({
+      items: [{
+        type: 'chart',
+        series: [{ label: 'A', data: [] }],
+      }],
+    }))).toBeNull()
+  })
+
+  it('keeps grouped bars valid with non-empty series data', () => {
+    const spec = resolveGenuiSpec(JSON.stringify({
+      items: [{
+        type: 'chart',
+        kind: 'bars',
+        series: [{ label: 'A', data: [{ label: '周一', value: 128 }] }],
+      }],
+    }))
+    expect(spec).not.toBeNull()
+    expect(spec!.items[0]).toMatchObject({ type: 'chart', kind: 'bars' })
+  })
+
+  it('allows extension fields but native repair ignores them', () => {
+    const spec = resolveGenuiSpec(JSON.stringify({
+      items: [{
+        type: 'chart',
+        kind: 'line',
+        data: [{ label: '周一', value: 128, extension: true }],
+        extension: { owner: 'another-plugin' },
+      }],
+    })) as { items: Array<Record<string, unknown> & { data?: Array<Record<string, unknown>> }> } | null
+
+    expect(spec).not.toBeNull()
+    expect(spec!.items[0]).not.toHaveProperty('extension')
+    expect(spec!.items[0]!.data?.[0]).not.toHaveProperty('extension')
+  })
+})

--- a/tests/plugin-genui.spec.ts
+++ b/tests/plugin-genui.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { Context } from '@deepseek-ai/cordis'
+import { Context, Service } from '@deepseek-ai/cordis'
 import SystemPrompt from '@deepseek-ai/dsh-system-prompt'
 import * as GenUI from '../src/plugin/index.ts'
 
@@ -38,6 +38,8 @@ describe('genui:fence section', () => {
     for (const type of ['text', 'card', 'grid', 'stat', 'table', 'audio', 'video', 'chart', 'tabs', 'button', 'progress', 'plot', 'callout', 'steps', 'diff', 'mermaid', 'scene3d']) {
       expect(text).toContain(type)
     }
+    expect(text).toContain('"kind":"bars|line|donut"')
+    expect(text).toContain('"label":"...","value":n')
   })
 
   it('keeps the full type whitelist in the slim section within the token budget', async () => {
@@ -89,6 +91,38 @@ describe('genui:fence section', () => {
     expect(registered).toHaveLength(2)
     const names = registered.map(t => (t as { name: string }).name).sort()
     expect(names).toEqual(['render_ui', 'validate_dsh_ui'])
+  })
+
+  it('registers the bundled genui skill when the skill service binds after the plugin', async () => {
+    const ctx = new Context()
+    await ctx.plugin(SystemPrompt)
+    const registered: Array<Record<string, unknown>> = []
+    class TestSkillRegistry extends Service {
+      constructor(inner: Context) { super(inner, 'skills') }
+
+      register(skill: Record<string, unknown>): () => void {
+        return this.ctx.effect(() => {
+          registered.push(skill)
+          return () => {
+            const index = registered.indexOf(skill)
+            if (index >= 0) registered.splice(index, 1)
+          }
+        }, 'test skill registration')
+      }
+    }
+    const genui = await ctx.plugin(GenUI)
+    await ctx.plugin(TestSkillRegistry)
+    expect(registered).toHaveLength(1)
+    expect(registered[0]).toMatchObject({
+      name: 'genui',
+      provider: '@changfenhuang/dsh-genui',
+      source: 'bundled',
+    })
+    expect(String(registered[0]!.description)).toContain('完整组件与字段规范')
+    expect(String(registered[0]!.content)).toContain('chart:')
+    expect(String(registered[0]!.content)).not.toContain('name: genui')
+    await genui.dispose()
+    expect(registered).toHaveLength(0)
   })
 
   it('keeps the fence channel without a tools service', async () => {

--- a/tests/plugin-genui.spec.ts
+++ b/tests/plugin-genui.spec.ts
@@ -40,6 +40,7 @@ describe('genui:fence section', () => {
     }
     expect(text).toContain('"kind":"bars|line|donut"')
     expect(text).toContain('"label":"...","value":n')
+    expect(text).toContain('series 仅 bars')
   })
 
   it('keeps the full type whitelist in the slim section within the token budget', async () => {
@@ -93,34 +94,52 @@ describe('genui:fence section', () => {
     expect(names).toEqual(['render_ui', 'validate_dsh_ui'])
   })
 
-  it('registers the bundled genui skill when the skill service binds after the plugin', async () => {
+  it('registers genui as a real bundled provider when the skill service binds after the plugin', async () => {
     const ctx = new Context()
     await ctx.plugin(SystemPrompt)
-    const registered: Array<Record<string, unknown>> = []
+    type Candidate = Record<string, unknown>
+    type Provider = {
+      name: string
+      list(): Promise<Candidate[]>
+      get(candidate: Candidate): Promise<Record<string, unknown>>
+    }
+    const registered: Provider[] = []
     class TestSkillRegistry extends Service {
       constructor(inner: Context) { super(inner, 'skills') }
 
-      register(skill: Record<string, unknown>): () => void {
+      registerProvider(create: () => Provider): () => void {
+        const provider = create()
         return this.ctx.effect(() => {
-          registered.push(skill)
+          registered.push(provider)
           return () => {
-            const index = registered.indexOf(skill)
+            const index = registered.indexOf(provider)
             if (index >= 0) registered.splice(index, 1)
           }
-        }, 'test skill registration')
+        }, 'test bundled skill provider registration')
       }
     }
     const genui = await ctx.plugin(GenUI)
     await ctx.plugin(TestSkillRegistry)
     expect(registered).toHaveLength(1)
-    expect(registered[0]).toMatchObject({
+    const provider = registered[0]!
+    expect(provider.name).toBe('dsh-genui')
+    const candidates = await provider.list()
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]).toMatchObject({
       name: 'genui',
-      provider: '@changfenhuang/dsh-genui',
+      provider: 'dsh-genui',
+      source: 'bundled',
+      rank: 600,
+    })
+    const skill = await provider.get(candidates[0]!)
+    expect(skill).toMatchObject({
+      name: 'genui',
+      provider: 'dsh-genui',
       source: 'bundled',
     })
-    expect(String(registered[0]!.description)).toContain('完整组件与字段规范')
-    expect(String(registered[0]!.content)).toContain('chart:')
-    expect(String(registered[0]!.content)).not.toContain('name: genui')
+    expect(String(skill.description)).toContain('完整组件与字段规范')
+    expect(String(skill.content)).toContain('chart:')
+    expect(String(skill.content)).not.toContain('name: genui')
     await genui.dispose()
     expect(registered).toHaveLength(0)
   })

--- a/tests/plugin-tool.spec.ts
+++ b/tests/plugin-tool.spec.ts
@@ -113,6 +113,20 @@ describe('render_ui execute', () => {
       'items[0].variant is unsupported; use kind; items[0].data[0].label must be a string; items[0].data[0].value must be a finite number',
     )
   })
+
+  it('rejects series-only line charts instead of rendering an empty plot', async () => {
+    await expect(tool.execute({
+      spec: {
+        items: [{
+          type: 'chart',
+          kind: 'line',
+          series: [{ label: 'A', data: [{ label: '周一', value: 128 }] }],
+        }],
+      },
+    })).rejects.toThrow(
+      'items[0].series is only supported for bars; items[0].data is required for line',
+    )
+  })
 })
 
 describe('render_ui projections', () => {
@@ -186,6 +200,37 @@ describe('validate_dsh_ui tool', () => {
     expect(value).toContain('items[0].data[0].value must be a finite number')
   })
 
+  it('rejects line/donut series and empty chart collections before rendering', async () => {
+    const line = String(await vtool.execute({
+      spec: {
+        items: [{
+          type: 'chart',
+          kind: 'line',
+          series: [{ label: 'A', data: [{ label: '周一', value: 128 }] }],
+        }],
+      },
+    }))
+    expect(line).toContain('items[0].series is only supported for bars')
+    expect(line).toContain('items[0].data is required for line')
+
+    const empty = String(await vtool.execute({
+      spec: {
+        items: [{
+          type: 'chart',
+          data: [],
+          series: [{ label: 'A', data: [] }],
+        }],
+      },
+    }))
+    expect(empty).toContain('items[0].data must not be empty')
+    expect(empty).toContain('items[0].series[0].data must not be empty')
+
+    const emptySeries = String(await vtool.execute({
+      spec: { items: [{ type: 'chart', series: [] }] },
+    }))
+    expect(emptySeries).toContain('items[0].series must not be empty')
+  })
+
   it('keeps chart field validation after repairing fence JSON syntax', async () => {
     const value = String(await vtool.execute({
       spec: '{"items":[{"type":"chart","variant":"line","data":[{"label":"周一","value":128}],}],}',
@@ -195,18 +240,22 @@ describe('validate_dsh_ui tool', () => {
     expect(value).not.toContain('无需再验证')
   })
 
-  it('accepts the compact chart signature with unknown extension fields', async () => {
-    const value = String(await vtool.execute({
-      spec: {
-        items: [{
-          type: 'chart',
-          kind: 'line',
-          data: [{ label: '周一', value: 128, extension: true }],
-          extension: { owner: 'another-plugin' },
-        }],
-      },
-    }))
+  it('allows unknown chart extension fields but native repair ignores them', async () => {
+    const raw = {
+      items: [{
+        type: 'chart',
+        kind: 'line',
+        data: [{ label: '周一', value: 128, extension: true }],
+        extension: { owner: 'another-plugin' },
+      }],
+    }
+    const value = String(await vtool.execute({ spec: raw }))
     expect(value).toContain('✅')
+    const meta = tool.output.presentationMeta!({ spec: raw }) as {
+      items: Array<Record<string, unknown> & { data?: Array<Record<string, unknown>> }>
+    }
+    expect(meta.items[0]).not.toHaveProperty('extension')
+    expect(meta.items[0]!.data?.[0]).not.toHaveProperty('extension')
   })
 
   it('stays green when object-shaped tables heal instead of dropping', async () => {

--- a/tests/plugin-tool.spec.ts
+++ b/tests/plugin-tool.spec.ts
@@ -99,6 +99,20 @@ describe('render_ui execute', () => {
       spy.mockRestore()
     }
   })
+
+  it('rejects chart aliases and invalid data instead of silently rendering bars', async () => {
+    await expect(tool.execute({
+      spec: {
+        items: [{
+          type: 'chart',
+          variant: 'line',
+          data: [{ label: 1, value: '128' }],
+        }],
+      },
+    })).rejects.toThrow(
+      'items[0].variant is unsupported; use kind; items[0].data[0].label must be a string; items[0].data[0].value must be a finite number',
+    )
+  })
 })
 
 describe('render_ui projections', () => {
@@ -152,6 +166,47 @@ describe('validate_dsh_ui tool', () => {
     expect(value).toContain('❌')
     expect(value).toContain('声明了 2 个组件')
     expect(value).toContain('仅成功解析出 1 个')
+  })
+
+  it('reports the chart kind contract and field-level data errors', async () => {
+    const value = String(await vtool.execute({
+      spec: {
+        items: [{
+          type: 'chart',
+          variant: 'line',
+          kind: 'area',
+          data: [{ label: 1, value: Number.NaN }],
+        }],
+      },
+    }))
+    expect(value).toContain('❌ chart 字段验证失败')
+    expect(value).toContain('items[0].variant is unsupported; use kind')
+    expect(value).toContain('items[0].kind must be bars, line, or donut')
+    expect(value).toContain('items[0].data[0].label must be a string')
+    expect(value).toContain('items[0].data[0].value must be a finite number')
+  })
+
+  it('keeps chart field validation after repairing fence JSON syntax', async () => {
+    const value = String(await vtool.execute({
+      spec: '{"items":[{"type":"chart","variant":"line","data":[{"label":"周一","value":128}],}],}',
+    }))
+    expect(value).toContain('❌ chart 字段验证失败')
+    expect(value).toContain('items[0].variant is unsupported; use kind')
+    expect(value).not.toContain('无需再验证')
+  })
+
+  it('accepts the compact chart signature with unknown extension fields', async () => {
+    const value = String(await vtool.execute({
+      spec: {
+        items: [{
+          type: 'chart',
+          kind: 'line',
+          data: [{ label: '周一', value: 128, extension: true }],
+          extension: { owner: 'another-plugin' },
+        }],
+      },
+    }))
+    expect(value).toContain('✅')
   })
 
   it('stays green when object-shaped tables heal instead of dropping', async () => {


### PR DESCRIPTION
## Summary

- register the packaged `genui` skill through the public skill service lifecycle
- expose the compact `chart` signature in the permanent prompt
- reject `variant`, unsupported kinds, invalid labels, and non-finite values in both validation and rendering tools
- keep unknown extension fields valid and identify native chart kinds in the browser

## Verification

- `pnpm run check` (`439 passed`, `104 skipped`)
- real Plus Web acceptance discovered `/genui`, queried DataOps through MCP, and rendered a visible line chart
