### PR TITLE
fix: improve Windows prepack portability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,29 @@ jobs:
             e2e-*.png
             dsh-web.log
           if-no-files-found: ignore
+
+  windows-pack:
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22, 24]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.7.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Pack
+        run: npm pack --json

--- a/scripts/prepack.mjs
+++ b/scripts/prepack.mjs
@@ -8,13 +8,19 @@
  */
 import { spawnSync } from 'node:child_process'
 
-const pm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
-const result = spawnSync(pm, ['run', 'build'], {
-  env: process.env,
-  stdio: ['ignore', 'pipe', 'pipe'],
-})
+const isWindows = process.platform === 'win32'
+const result = spawnSync(
+  isWindows ? (process.env.ComSpec || 'cmd.exe') : 'pnpm',
+  isWindows
+    ? ['/d', '/s', '/c', 'pnpm run build']
+    : ['run', 'build'],
+  {
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  },
+)
 
-if (result.stdout !== null && result.stdout.length > 0) process.stderr.write(result.stdout)
-if (result.stderr !== null && result.stderr.length > 0) process.stderr.write(result.stderr)
-if (result.error !== undefined) throw result.error
+if (result.stdout?.length) process.stderr.write(result.stdout)
+if (result.stderr?.length) process.stderr.write(result.stderr)
+if (result.error) throw result.error
 if (result.status !== 0) process.exit(result.status ?? 1)


### PR DESCRIPTION
## Summary

修复 Windows 下 `prepack` 调用 `pnpm` 时的兼容性问题，并补充 Windows 打包 CI。

## Changes

* Windows 下通过 `ComSpec` / `cmd.exe` 执行 `pnpm run build`
* 保持 `npm pack --json` 的 stdout 不被构建日志污染
* 新增 Windows CI，覆盖 Node 22 / 24：

  * `pnpm install --frozen-lockfile`
  * `pnpm run build`
  * `npm pack --json`

## Scope

这个 PR 只处理仓库能够明确负责的 Windows portability。

没有修改 `tsx` / `esbuild` 版本。当前两个 `esbuild` 版本分别来自不同依赖链，本身不能说明 dependency tree 有问题；Windows CI 目前也已经通过，因此暂不做额外的依赖调整。
