### PR TITLE
fix: stop Windows table-hover text shift

### DIFF
--- a/src/client/GenuiBlock.module.css
+++ b/src/client/GenuiBlock.module.css
@@ -350,7 +350,6 @@
   line-height: 1.5;
 }
 .table tr:last-child td { border-bottom: none; }
-.table tbody tr { transition: background 0.12s; }
 .table tbody tr:hover { background: var(--dsl-g-hover); }
 /* Numeric columns (auto-detected) right-align with tabular numerals — the
    table's data voice. */
@@ -965,8 +964,7 @@ button.ftNameBtn[aria-expanded] { cursor: pointer; }
 /* "✓ 已触发" confirmation chip: appears next to the button without layout
    shift risk (it inherits the flex row's gap). `backwards`, not `both`: the
    chip's natural (post-animation) style is already visible/no-transform, so
-   pinning the end keyframe would only keep a translateY(0) transform layer
-   alive forever — the exact mechanism behind issues #55/#69. */
+   pinning the end keyframe would only retain an unnecessary transform. */
 .btnSent { animation: genuiPopIn 0.2s ease backwards; }
 
 /* 尊重用户的减弱动效偏好 */

--- a/tests/genui-table-scroll.spec.tsx
+++ b/tests/genui-table-scroll.spec.tsx
@@ -60,6 +60,13 @@ describe('GenUI table overflow', () => {
     expect(rule).toContain('max-width: 100%')
   })
 
+  it('does not animate table-row hover repaints (issue #55)', () => {
+    const css = readFileSync(join(process.cwd(), 'src/client/GenuiBlock.module.css'), 'utf8')
+    expect(css).toMatch(/\.table tbody tr:hover\s*\{[^}]*background:/)
+    const restingRule = /\.table tbody tr\s*\{([^}]*)\}/.exec(css)
+    expect(restingRule?.[1] ?? '').not.toMatch(/\btransition\s*:/)
+  })
+
   it('releases the reveal transform after animation', () => {
     const css = readFileSync(join(process.cwd(), 'src/client/GenuiBlock.module.css'), 'utf8')
     const match = /\.reveal\s*\{([^}]*)\}/.exec(css)
@@ -68,12 +75,10 @@ describe('GenUI table overflow', () => {
     expect(match![1]).not.toContain('both')
   })
 
-  it('no animation pins a transform past its end (issues #55/#69)', () => {
+  it('no animation pins a transform past its end', () => {
     // fill-mode both/forwards keeps the end keyframe (translateY(0)) applied
-    // forever: the element keeps a live transform layer, and hover-triggered
-    // repaints nearby then shift adjacent content on Windows Chromium.
-    // Every entrance/pop animation must release via backwards/none — natural
-    // styles take over after the animation ends.
+    // after completion. Every entrance/pop animation releases via
+    // backwards/none so the natural styles take over after the animation.
     const css = readFileSync(join(process.cwd(), 'src/client/GenuiBlock.module.css'), 'utf8')
     const animations = [...css.matchAll(/animation:\s*([^;]+);/g)].map(m => m[1]!)
     expect(animations.length).toBeGreaterThan(0)


### PR DESCRIPTION
## 根因

旧修复把问题归因于入场动画残留，但报告者在完整包含该修复的版本上仍能复现。真实触发源是表格行的 120ms 背景色过渡：鼠标从表格移到紧邻文字时，表格退场过渡仍在运行，Windows Chromium 重绘表格绘制面时会让相邻文字产生视觉抖动。

## 修复

- 删除表格行背景色过渡，保留瞬时 hover 底色
- 增加回归检查，禁止表格行再次引入 transition
- 更正把 55/69 误归因于入场动画的注释
- 仅修改 dsh-genui 插件，不修改或 patch DSH 本体

## 验证

- npm run check：47 个测试文件通过，435 条测试通过，类型检查与构建通过
- node scripts/verify-pack.mjs：通过
- 未修改的 DSH 0.1.2-alpha.1 隔离 Web smoke：通过

Related to #55

合并后保留 issue 开启，等待报告者在原 Windows 环境复测。