### PR TITLE
fix(skill): align with DSH skill service declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react": "^18.3.1"
   },
   "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0",
     "@deepseek-ai/dsh-client-ui-conversation": "^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0",
     "@deepseek-ai/dsh-client-ui-input-trigger": "^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0",
@@ -73,9 +74,9 @@
     "@deepseek-ai/dsh-invariants": "^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0",
     "@deepseek-ai/dsh-llm": "^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0",
     "@deepseek-ai/dsh-session": "^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0",
+    "@deepseek-ai/dsh-skill": "^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0",
     "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0",
     "@deepseek-ai/dsh-tools": "^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0",
-    "@deepseek-ai/cordis": "^4.0.1",
     "react": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
@@ -85,18 +86,18 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/three": "^0.185.4",
+    "echarts": "^5.6.0",
     "jsdom": "^25.0.0",
     "lightningcss": "^1.25.0",
+    "mermaid": "11.16.0",
+    "react-dom": "^18.3.1",
+    "three": "^0.180.0",
     "tsdown": "^0.22.2",
     "tsx": "^4.0.0",
     "typescript": "^5.6.0",
     "vite": "^6.0.0",
     "vitest": "^3.0.0",
-    "echarts": "^5.6.0",
-    "yaml": "^2.4.2",
-    "mermaid": "11.16.0",
-    "three": "^0.180.0",
-    "react-dom": "^18.3.1"
+    "yaml": "^2.4.2"
   },
   "scripts": {
     "build": "rm -rf lib && tsc -p tsconfig.json && tsdown",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@deepseek-ai/dsh-session':
         specifier: ^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0
         version: 0.1.0-rc.8(4345a04528ba5fe6fca14c14c75a9257)
+      '@deepseek-ai/dsh-skill':
+        specifier: ^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-system-prompt':
         specifier: ^0.1.0-rc.8 || >=0.1.1-rc.0 <0.2.0
         version: 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
@@ -711,6 +714,14 @@ packages:
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
       '@deepseek-ai/dsh-llm': ^0.1.0-rc.6
       '@deepseek-ai/dsh-scope': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-skill@0.1.1-rc.2':
+    resolution: {integrity: sha512-FACjlOqdsWX+0RtSs3RWrdY0QQEpPJrBfvxUbWSh7E8UyCM8dKdIbsQnuXIjsAgC7GgYp7lyFDSCMovQ3ARp8g==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-llm': ^0.1.1-rc.2
+      '@deepseek-ai/dsh-scope': ^0.1.1-rc.2
 
   '@deepseek-ai/dsh-storage-domain@0.1.0-rc.6':
     resolution: {integrity: sha512-/5qDCIIf9JNpoRG5VrY/CXFIuch1tDE0H5XREHsKd6LE26TOHcTAUH6gyersFG4e3TPoOLJYDp1+SapFLd7+kQ==}
@@ -3715,6 +3726,14 @@ snapshots:
       '@deepseek-ai/dsh-subprocess': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
 
   '@deepseek-ai/dsh-skill@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-llm': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-scope': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/schemastery': 3.18.1
+
+  '@deepseek-ai/dsh-skill@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.8(@deepseek-ai/cordis@4.0.1)

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -13,6 +13,7 @@
 import { Context } from '@deepseek-ai/cordis'
 import type {} from '@deepseek-ai/dsh-system-prompt'
 import type {} from '@deepseek-ai/dsh-tools'
+import type { SkillProvider } from '@deepseek-ai/dsh-skill'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
@@ -129,34 +130,8 @@ const BUNDLED_SKILL_PROVIDER = 'dsh-genui'
 const BUNDLED_SKILL_DESCRIPTION = 'GenUI 完整组件与字段规范，用于生成 dsh-ui 结构化交互界面。'
 const BUNDLED_SKILL_INVOCATION = { modelInvocable: true, userInvocable: true } as const
 
-type BundledSkill = {
-  name: string
-  description: string
-  invocation: typeof BUNDLED_SKILL_INVOCATION
-  source: 'bundled'
-  provider: string
-  path: string
-  resourceBase: { kind: 'directory'; path: string }
-  content: string
-}
-
-type BundledSkillCandidate = Omit<BundledSkill, 'content'> & {
-  rank: number
-  locator: string
-}
-
-type BundledSkillProvider = {
-  name: string
-  list(): Promise<BundledSkillCandidate[]>
-  get(candidate: BundledSkillCandidate): Promise<BundledSkill>
-}
-
-type SkillRegistry = {
-  registerProvider(create: () => BundledSkillProvider): () => void
-}
-
-/** Resolve the packaged skill from both source and built module locations. */
-function bundledSkill(): BundledSkill {
+/** Register through the provider path so source=bundled also gets bundled precedence. */
+function bundledSkillProvider(): SkillProvider {
   const moduleDirectory = dirname(fileURLToPath(new URL(import.meta.url)))
   const path = basename(moduleDirectory) === 'plugin'
     ? resolve(moduleDirectory, '../../SKILL.md')
@@ -165,35 +140,28 @@ function bundledSkill(): BundledSkill {
   const end = raw.indexOf('\n---\n', 4)
   if (!raw.startsWith('---\n') || end < 0) throw new Error('genui SKILL.md has invalid frontmatter')
   return {
-    name: 'genui',
-    description: BUNDLED_SKILL_DESCRIPTION,
-    invocation: BUNDLED_SKILL_INVOCATION,
-    source: 'bundled',
-    provider: BUNDLED_SKILL_PROVIDER,
-    path,
-    resourceBase: { kind: 'directory', path: dirname(path) },
-    content: raw.slice(end + 5),
-  }
-}
-
-/** Register through the provider path so source=bundled also gets bundled precedence. */
-function bundledSkillProvider(): BundledSkillProvider {
-  const skill = bundledSkill()
-  const candidate: BundledSkillCandidate = {
-    name: skill.name,
-    description: skill.description,
-    invocation: skill.invocation,
-    source: skill.source,
-    provider: skill.provider,
-    path: skill.path,
-    resourceBase: skill.resourceBase,
-    rank: BUNDLED_SKILL_RANK,
-    locator: skill.path,
-  }
-  return {
     name: BUNDLED_SKILL_PROVIDER,
-    list: () => Promise.resolve([candidate]),
-    get: () => Promise.resolve(skill),
+    list: () => Promise.resolve([{
+      name: 'genui',
+      description: BUNDLED_SKILL_DESCRIPTION,
+      invocation: BUNDLED_SKILL_INVOCATION,
+      source: 'bundled',
+      provider: BUNDLED_SKILL_PROVIDER,
+      path,
+      resourceBase: { kind: 'directory', path: dirname(path) },
+      rank: BUNDLED_SKILL_RANK,
+      locator: path,
+    }]),
+    get: () => Promise.resolve({
+      name: 'genui',
+      description: BUNDLED_SKILL_DESCRIPTION,
+      invocation: BUNDLED_SKILL_INVOCATION,
+      source: 'bundled',
+      provider: BUNDLED_SKILL_PROVIDER,
+      path,
+      resourceBase: { kind: 'directory', path: dirname(path) },
+      content: raw.slice(end + 5),
+    }),
   }
 }
 
@@ -231,8 +199,7 @@ export function apply(ctx: Context): void {
   })
 
   ctx.inject(['skills'], (skillCtx) => {
-    const skills = (skillCtx as Context & { skills: SkillRegistry }).skills
-    skills.registerProvider(() => bundledSkillProvider())
+    skillCtx.skills.registerProvider(() => bundledSkillProvider())
   })
 
   // Lazy-engine asset route: same optional-probe pattern as the tools

--- a/tests/plugin-genui.spec.ts
+++ b/tests/plugin-genui.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { Context, Service } from '@deepseek-ai/cordis'
+import { Context } from '@deepseek-ai/cordis'
+import SkillRegistry from '@deepseek-ai/dsh-skill'
 import SystemPrompt from '@deepseek-ai/dsh-system-prompt'
 import * as GenUI from '../src/plugin/index.ts'
 
@@ -94,54 +95,51 @@ describe('genui:fence section', () => {
     expect(names).toEqual(['render_ui', 'validate_dsh_ui'])
   })
 
-  it('registers genui as a real bundled provider when the skill service binds after the plugin', async () => {
+  it('registers genui through the real skill registry', async () => {
     const ctx = new Context()
     await ctx.plugin(SystemPrompt)
-    type Candidate = Record<string, unknown>
-    type Provider = {
-      name: string
-      list(): Promise<Candidate[]>
-      get(candidate: Candidate): Promise<Record<string, unknown>>
-    }
-    const registered: Provider[] = []
-    class TestSkillRegistry extends Service {
-      constructor(inner: Context) { super(inner, 'skills') }
+    await ctx.plugin(SkillRegistry)
 
-      registerProvider(create: () => Provider): () => void {
-        const provider = create()
-        return this.ctx.effect(() => {
-          registered.push(provider)
-          return () => {
-            const index = registered.indexOf(provider)
-            if (index >= 0) registered.splice(index, 1)
-          }
-        }, 'test bundled skill provider registration')
-      }
-    }
     const genui = await ctx.plugin(GenUI)
-    await ctx.plugin(TestSkillRegistry)
-    expect(registered).toHaveLength(1)
-    const provider = registered[0]!
-    expect(provider.name).toBe('dsh-genui')
-    const candidates = await provider.list()
-    expect(candidates).toHaveLength(1)
-    expect(candidates[0]).toMatchObject({
-      name: 'genui',
-      provider: 'dsh-genui',
-      source: 'bundled',
-      rank: 600,
-    })
-    const skill = await provider.get(candidates[0]!)
+
+    expect(await ctx.skills.list()).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'genui',
+        provider: 'dsh-genui',
+        source: 'bundled',
+        invocation: {
+          modelInvocable: true,
+          userInvocable: true,
+        },
+      }),
+    ]))
+
+    const skill = await ctx.skills.get('genui')
     expect(skill).toMatchObject({
       name: 'genui',
       provider: 'dsh-genui',
       source: 'bundled',
     })
-    expect(String(skill.description)).toContain('完整组件与字段规范')
-    expect(String(skill.content)).toContain('chart:')
-    expect(String(skill.content)).not.toContain('name: genui')
+    expect(skill?.description).toContain('完整组件与字段规范')
+    expect(skill?.content).toContain('chart:')
+    expect(skill?.content).not.toContain('name: genui')
+
     await genui.dispose()
-    expect(registered).toHaveLength(0)
+    expect((await ctx.skills.list()).find(skill => skill.name === 'genui')).toBeUndefined()
+  })
+
+  it('registers genui when the real skill service binds after the plugin', async () => {
+    const ctx = new Context()
+    await ctx.plugin(SystemPrompt)
+    await ctx.plugin(GenUI)
+    await ctx.plugin(SkillRegistry)
+
+    expect((await ctx.skills.list()).find(skill => skill.name === 'genui')).toMatchObject({
+      name: 'genui',
+      provider: 'dsh-genui',
+      source: 'bundled',
+    })
+    expect(await ctx.skills.get('genui')).toBeDefined()
   })
 
   it('keeps the fence channel without a tools service', async () => {


### PR DESCRIPTION
## 改动内容

* 显式补充 `@deepseek-ai/dsh-skill` 依赖；
* 使用官方 `SkillProvider` ；
* 使用 DSH 通过 module augmentation 提供的 `Context.skills`，去掉手工的 `Context & { skills: ... }` 类型断言；
* 将原有 fake skill registry 测试替换为真实 `SkillRegistry` 集成测试。

## 原因

#89 已经通过 `ctx.skills.registerProvider(...)` 实现了 bundled `genui` skill 注册，但当时为了接入 `skills` service，在 GenUI 内部自行补了一套类型定义。
DSH 官方的 `@deepseek-ai/dsh-skill` 已经提供了 `SkillProvider`，并对 Cordis `Context` 声明了 `ctx.skills: SkillRegistry`，因此这里应直接使用官方定义，避免维护一份平行 contract。
最初曾观察到“调整类型定义后 skill 可以正常注入”，但目前不把类型修改本身视为已确认的运行时根因。`import type`、module augmentation 和类型断言在编译后都会被擦除，实际现象也可能受到依赖解析、重新构建/加载或宿主启动状态等因素影响。

## 测试

真实 `SkillRegistry` 集成测试覆盖：

* `SkillRegistry → GenUI` 启动顺序；
* `GenUI → SkillRegistry` 晚绑定顺序；
* `ctx.skills.list()` 能发现 `genui`；
* `ctx.skills.get('genui')` 能读取 bundled `SKILL.md`；
* 插件 dispose 后 provider 能正常移除。
