### PR TITLE
chore(release): 准备 0.9.7 发布

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@changfenhuang/dsh-genui",
   "description": "GenUI for DeepSeek Harness: interactive UI components rendered inline in assistant replies via the ```dsh-ui fence — layout, charts, plots, forms, quizzes, mermaid, 3D scenes, and an action event loop back to the model. Ships the fence-teaching host plugin, the browser renderer (client half), and the genui skill.",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/types/plugin/index.d.ts",


### PR DESCRIPTION
## 改动

- 将 `package.json` 版本从 `0.9.6` 升到 `0.9.7`
- 不包含功能代码改动，不提交 `lib/` 构建产物

## 发布范围

`v0.9.6...main` 已包含 GenUI skill 自动注册与官方 SkillProvider 对齐、chart contract 强化、`image` 组件、Windows prepack 修复，以及多项状态和渲染修复。

## 验证

当前 `main` CI 已通过：

- Node 22 + `dsh-v0.1.1-rc.2`
- Node 24 + `dsh-v0.1.2-alpha.1`
- Windows Node 22 / 24 build + pack

合并后可创建正式 GitHub Release `v0.9.7`，触发 npm `latest` 发布。