### PR TITLE
fix(client): /panel 候选按 query 前缀过滤，不再抢占 slash 菜单默认高亮

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### 修复
+- **/panel 候选按 query 前缀过滤（issue #98）**：`createPanelSlashSource` 的 `candidates` 此前无视 `req.query` 恒返回 `panel` 一项——输入与指令/技能都不匹配的 query 时，genui 组成了菜单里唯一 ready 非空的分组，宿主 `menuReduce` 的 `firstHighlight` 落到 `panel` 且后续不让位，默认高亮被抢占；此时按 Enter 走 `pick-highlighted` 会误执行 `/panel` 而非目标命令/技能。现在 query 非空且不是 `panel` 前缀（大小写不敏感）时返回空数组，该分组从菜单消失。`matchEnter` 行为不变（裸 `/panel` 回车照常认领）。
+
 ## [0.9.6] - 2026-08-28
 ### 兼容性
 - **dsh 0.1.2-alpha.1**：真机验收改为读取新版 Web 启动时生成的一次性令牌地址，先建立浏览器登录态，再按启动图公告的不可变组合地址检查插件资源；后台启动显式使用 `--no-open`，不再误开用户浏览器。插件运行代码和宿主配置契约无需兼容层，也未修改 dsh 本体；官方标签源码构建在 Node 24.13 下完成 macOS 真机页面激活，启动图资源返回 200。Node 24.11 会令该宿主启动图为空，验收与本机入口已固定使用 24.13。

--- a/src/client/panel-command.ts
+++ b/src/client/panel-command.ts
@@ -103,11 +103,20 @@ export function createPanelSlashSource(sendInstruction: (sessionId: SessionId, i
     trigger: '/',
     name: 'genui',
     order: 60,
-    candidates: async (_session, _req) => [{
-      name: 'panel',
-      description: '开启 GenUI 面板（/panel clear 清空；/panel <指令> 定制内容）',
-      hint: '/panel',
-    }],
+    candidates: async (_session, req) => {
+      // Filter by query prefix: once the user types past "panel" the genui
+      // group must disappear. Unfiltered candidates kept this group the only
+      // ready non-empty group for unmatched queries, so the menu's default
+      // highlight fell through to `panel` and Enter picked it instead of the
+      // intended command/skill candidate.
+      const query = (req?.query ?? '').trim().toLowerCase()
+      if (query !== '' && !'panel'.startsWith(query)) return []
+      return [{
+        name: 'panel',
+        description: '开启 GenUI 面板（/panel clear 清空；/panel <指令> 定制内容）',
+        hint: '/panel',
+      }]
+    },
     onPick(pick) {
       return { claim: panelClaim(pick.session.sessionId, sendInstruction) }
     },

--- a/src/client/panel-command.ts
+++ b/src/client/panel-command.ts
@@ -109,7 +109,7 @@ export function createPanelSlashSource(sendInstruction: (sessionId: SessionId, i
       // ready non-empty group for unmatched queries, so the menu's default
       // highlight fell through to `panel` and Enter picked it instead of the
       // intended command/skill candidate.
-      const query = (req?.query ?? '').trim().toLowerCase()
+      const query = req.query.toLowerCase()
       if (query !== '' && !'panel'.startsWith(query)) return []
       return [{
         name: 'panel',

--- a/tests/panel-command.spec.ts
+++ b/tests/panel-command.spec.ts
@@ -35,6 +35,21 @@ describe('/panel slash source', () => {
     expect(candidates[0]!.name).toBe('panel')
   })
 
+  it('filters the candidate by query prefix so the group vanishes for unmatched queries', async () => {
+    const call = (query: string): Promise<readonly { name: string }[]> =>
+      source.candidates!({ sessionId: SID } as never, { query, position: 'leading', signal: new AbortController().signal })
+    // Bare "/" and any prefix of "panel" (case-insensitive) keep the candidate.
+    for (const query of ['', 'p', 'pa', 'PANEL', ' panel ']) {
+      expect(await call(query)).toHaveLength(1)
+    }
+    // Anything else must drop the group: an unfiltered group stays the only
+    // ready non-empty group for unmatched queries and steals the menu's
+    // default highlight from real command/skill candidates.
+    for (const query of ['sk', 'venus', 'zzz', 'panels']) {
+      expect(await call(query)).toHaveLength(0)
+    }
+  })
+
   it('publishes the default spec and requests expansion on pick', async () => {
     const before = getPanelExpandToken(SID)
     const outcome = source.onPick!({

--- a/tests/panel-command.spec.ts
+++ b/tests/panel-command.spec.ts
@@ -39,13 +39,13 @@ describe('/panel slash source', () => {
     const call = (query: string): Promise<readonly { name: string }[]> =>
       source.candidates!({ sessionId: SID } as never, { query, position: 'leading', signal: new AbortController().signal })
     // Bare "/" and any prefix of "panel" (case-insensitive) keep the candidate.
-    for (const query of ['', 'p', 'pa', 'PANEL', ' panel ']) {
+    for (const query of ['', 'p', 'pa', 'PANEL']) {
       expect(await call(query)).toHaveLength(1)
     }
     // Anything else must drop the group: an unfiltered group stays the only
     // ready non-empty group for unmatched queries and steals the menu's
     // default highlight from real command/skill candidates.
-    for (const query of ['sk', 'venus', 'zzz', 'panels']) {
+    for (const query of ['sk', 'venus', 'zzz', 'panels', ' panel ']) {
       expect(await call(query)).toHaveLength(0)
     }
   })


### PR DESCRIPTION
Fixes #98

## 问题

`createPanelSlashSource` 的 `candidates` 无视 `req.query` 恒返回 `panel` 一项。输入与指令/技能都不匹配的 query 时，genui 组成了菜单里唯一 ready 非空的分组：宿主 `menuReduce` 的 `firstHighlight` 落到 `panel` 且后续不让位，默认高亮被抢占；此时按 Enter 走 `pick-highlighted` 会**误执行 /panel** 而非目标命令/技能（详见 issue #98 根因链）。

## 改动

- `src/client/panel-command.ts`：`candidates` 按 query 前缀过滤——query 为空（裸 `/`）或 `panel`.startsWith(query)（大小写不敏感，trim 后比较）时返回候选，否则返回 `[]`，该分组从菜单消失。
- `matchEnter` 不变：裸 `/panel` / `/panel clear` / `/panel <指令>` 回车照常认领，无回归面。
- `tests/panel-command.spec.ts`：新增用例覆盖空 query、前缀（含大写与空白）、非前缀（`sk` / `venus` / `zzz` / `panels`）四类输入。
- `CHANGELOG.md`：[Unreleased] 补修复条目。

## 验证

- `npx vitest run tests/panel-command.spec.ts` → **8 passed**（原 7 + 新增 1）；
- `npx tsc -p tsconfig.json` → 0 错误；
- 全量 `vitest run` 与 main 基线逐项对比：passed 360 vs 359（+1 为本 PR 新用例），failed 90 vs 90 **完全一致**——失败项（achievements / genui-panel / genui-v27 等）为本机 Node 26 环境的既有失败，与本改动无关（CI Node 22/24 基线全绿）。

## 影响面

仅 `/` 菜单里 genui 分组的候选可见性；`/panel` 命令本身的执行路径（菜单选中、matchEnter）行为不变。