### PR TITLE
refactor: simplify GenUI render dispatcher

### DIFF
--- a/src/client/blocks/advanced.tsx
+++ b/src/client/blocks/advanced.tsx
@@ -1,6 +1,6 @@
 /**
  * Advanced family: callout/steps/keyvalue, plot/diff/json/code, tabs and
- * accordion containers (recursing through renderNode), copy, mermaid,
+ * accordion containers with injected child rendering, copy, mermaid,
  * scene3d, timeline, file-tree, quiz, breadcrumb.
  * @module @changfenhuang/dsh-genui/client/blocks/advanced
  */
@@ -9,11 +9,10 @@ import { CodeBlock, DiffBlock, JsonTree, writeClipboard } from '@deepseek-ai/dsh
 import css from '../GenuiBlock.module.css'
 import { GENUI_LIMITS } from '../genui-runtime/index.ts'
 import { PlotBlock } from '../PlotBlock.tsx'
-import { renderNode } from './render-node.tsx'
-import type { AnswersState, GenuiBlockProps } from './state.ts'
+import type { GenuiBlockProps } from './state.ts'
 import type {
   GenuiAccordion, GenuiBreadcrumb, GenuiCallout, GenuiCode, GenuiCopy, GenuiDiff, GenuiFileTree, GenuiFileTreeNode,
-  GenuiJson, GenuiKeyValue, GenuiMermaid, GenuiPlot, GenuiQuiz, GenuiScene3D, GenuiSteps, GenuiTabs, GenuiTimeline,
+  GenuiJson, GenuiKeyValue, GenuiMermaid, GenuiNode, GenuiPlot, GenuiQuiz, GenuiScene3D, GenuiSteps, GenuiTabs, GenuiTimeline,
 } from '../spec.ts'
 
 const CALLOUT_TONES: Record<string, string> = {
@@ -112,11 +111,9 @@ export const CodeNode = memo(function CodeNode({ node }: { node: GenuiCode }) {
  * round trip. Numeric cells (numbers or numeric strings) compare numerically;
  * everything else compares as text.
  */
-export function TabsNode({ tabs, onAction, depth = 0, answers }: {
+export function TabsNode({ tabs, renderChild }: {
   tabs: GenuiTabs
-  onAction?: GenuiBlockProps['onAction']
-  depth?: number
-  answers?: AnswersState | undefined
+  renderChild: (node: GenuiNode, key: number) => ReactNode
 }) {
   const [active, setActive] = useState(0)
   const uid = useId()
@@ -163,7 +160,7 @@ export function TabsNode({ tabs, onAction, depth = 0, answers }: {
       </div>
       {current !== undefined && (
         <div className={css.col} role="tabpanel" id={`${uid}-panel-${safeActive}`} aria-labelledby={`${uid}-tab-${safeActive}`}>
-          {current.items.map((c, i) => renderNode(c, i, onAction, depth + 1, answers))}
+          {current.items.map((c, i) => renderChild(c, i))}
         </div>
       )}
     </div>
@@ -179,11 +176,9 @@ export function TabsNode({ tabs, onAction, depth = 0, answers }: {
  * carry `answer` data) or collects all groups in ONE action. Without
  * `group`, the legacy per-click action fires. After a local grading the
  * group locks until 重新作答 resets it. */
-export function AccordionNode({ node, onAction, depth = 0, answers }: {
+export function AccordionNode({ node, renderChild }: {
   node: GenuiAccordion
-  onAction?: GenuiBlockProps['onAction']
-  depth?: number
-  answers?: AnswersState | undefined
+  renderChild: (node: GenuiNode, key: number) => ReactNode
 }) {
   const [open, setOpen] = useState<number | null>(0)
   const uid = useId()
@@ -205,7 +200,7 @@ export function AccordionNode({ node, onAction, depth = 0, answers }: {
           </button>
           {open === i && (
             <div className={css.accBody} id={`${uid}-body-${i}`} aria-labelledby={`${uid}-head-${i}`}>
-              {item.items.map((c, ci) => renderNode(c, ci, onAction, depth + 1, answers))}
+              {item.items.map((c, ci) => renderChild(c, ci))}
             </div>
           )}
         </div>

--- a/src/client/blocks/basic.tsx
+++ b/src/client/blocks/basic.tsx
@@ -1,11 +1,15 @@
 /**
- * Basic display family: avatar palette, and the local click-feedback button
- * (the actionable-button chip). Used by the render dispatcher.
+ * Basic display family: simple leaf renderers, media, avatar palette,
+ * and the local click-feedback button. Used by the render dispatcher.
  * @module @changfenhuang/dsh-genui/client/blocks/basic
  */
 import { memo, useEffect, useRef, useState, type ReactNode } from 'react'
 import css from '../GenuiBlock.module.css'
-import type { GenuiAudio, GenuiVideo } from '../spec.ts'
+import type {
+  GenuiAudio, GenuiAvatar, GenuiBadge, GenuiButton, GenuiLink,
+  GenuiProgress, GenuiStat, GenuiText, GenuiVideo,
+} from '../spec.ts'
+import type { GenuiBlockProps } from './state.ts'
 
 /** Deterministic avatar color by name hash. Host static tokens ONLY —
  * design system v2: no off-brand hexes, the palette always matches the
@@ -52,10 +56,10 @@ export function ClickFeedbackButton({ className, disabled, onClick, children }: 
         className={className}
         disabled={disabled}
         onClick={onClick === undefined ? undefined : () => {
-          onClick()
-          if (timer.current !== null) clearTimeout(timer.current)
-          setSent(true)
-          timer.current = setTimeout(() => setSent(false), 1400)
+onClick()
+if (timer.current !== null) clearTimeout(timer.current)
+setSent(true)
+timer.current = setTimeout(() => setSent(false), 1400)
         }}
       >
         {children}
@@ -65,6 +69,99 @@ export function ClickFeedbackButton({ className, disabled, onClick, children }: 
        * the "已触发" confirmation announces from a hidden status region. */}
       <span className={css.visuallyHidden} role="status">{sent ? '已触发' : ''}</span>
     </>
+  )
+}
+
+export function TextNode({ node }: { node: GenuiText }): ReactNode {
+  const size = node.size ?? 'body'
+  return (
+    <div className={`${css.text} ${css[size]}` + (node.center ? ` ${css.center}` : '')}>
+      {node.content}
+    </div>
+  )
+}
+
+export function ButtonNode({ node, onAction }: {
+  node: GenuiButton
+  onAction?: GenuiBlockProps['onAction']
+}): ReactNode {
+  const tone = node.tone ?? ''
+  const cls = `${css.button} ${css[tone] || ''}` + (node.full ? ` ${css.full}` : '') + (node.small ? ` ${css.small}` : '')
+  const action = node.action
+  // A button without an action (or without an action provider) is a
+  // display-only control: render it DISABLED so the affordance is honest
+  // — clickable-looking dead buttons were the top complaint in the field.
+  const interactive = action !== undefined && onAction !== undefined
+  return (
+    <ClickFeedbackButton
+      className={cls}
+      disabled={!interactive}
+      onClick={interactive ? () => onAction(action, { type: 'button', label: node.label }) : undefined}
+    >
+      {node.icon !== undefined && <span aria-hidden>{node.icon} </span>}
+      {node.label}
+    </ClickFeedbackButton>
+  )
+}
+
+export function LinkNode({ node }: { node: GenuiLink }): ReactNode {
+  // Honest affordance: with a whitelisted href this is a REAL anchor;
+  // without one it is plain styled text (a dead clickable-looking button
+  // was the same complaint class as the disabled-button fix).
+  const href = node.href
+  return href !== undefined
+    ? <a className={css.link} href={href} target="_blank" rel="noopener noreferrer">{node.label}</a>
+    : <span className={css.linkText}>{node.label}</span>
+}
+
+export function BadgeNode({ node }: { node: GenuiBadge }): ReactNode {
+  const tone = node.tone ?? ''
+  return (
+    <span className={`${css.badge} ${css[tone] || ''}`}>
+      {node.icon !== undefined && <span aria-hidden>{node.icon} </span>}
+      {node.label}
+    </span>
+  )
+}
+
+export function StatNode({ node }: { node: GenuiStat }): ReactNode {
+  const down = node.delta !== undefined && node.delta.startsWith('-')
+  return (
+    <div className={css.stat}>
+      <span className={css.statLabel}>{node.label}</span>
+      <span className={css.statValue}>{node.value}</span>
+      {node.delta !== undefined && <span className={`${css.statDelta} ${down ? css.down : css.up}`}>{node.delta}</span>}
+    </div>
+  )
+}
+
+export function ProgressNode({ node }: { node: GenuiProgress }): ReactNode {
+  const v = Math.max(0, Math.min(100, Number(node.value) || 0))
+  return (
+    <div
+      className={css.progress}
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={v}
+      aria-label={node.label ?? node.valueLabel ?? undefined}
+    >
+      {(node.label !== undefined || node.valueLabel !== undefined) && (
+        <div className={css.progressRow}>
+<span>{node.label}</span>
+{node.valueLabel !== undefined && <span>{node.valueLabel}</span>}
+        </div>
+      )}
+      <div className={css.track}><div className={css.fill} style={{ width: `${v}%` }} /></div>
+    </div>
+  )
+}
+
+export function AvatarNode({ node }: { node: GenuiAvatar }): ReactNode {
+  return (
+    <div className={css.avatar} style={{ background: node.color ?? avatarColor(node.name) }}>
+      {node.name.slice(0, 1).toUpperCase()}
+    </div>
   )
 }
 
@@ -79,14 +176,14 @@ export const AudioNode = memo(function AudioNode({ node }: { node: GenuiAudio })
       {failed
         ? <div className={css.mediaError} role="alert">音频无法播放</div>
         : <audio
-            className={css.mediaPlayer}
-            src={node.src}
-            aria-label={node.alt ?? '音频'}
-            controls
-            preload="metadata"
-            loop={node.loop === true}
-            onError={() => setFailed(true)}
-          />}
+  className={css.mediaPlayer}
+  src={node.src}
+  aria-label={node.alt ?? '音频'}
+  controls
+  preload="metadata"
+  loop={node.loop === true}
+  onError={() => setFailed(true)}
+/>}
     </figure>
   )
 })
@@ -99,18 +196,18 @@ export const VideoNode = memo(function VideoNode({ node }: { node: GenuiVideo })
       {failed
         ? <div className={css.mediaError} role="alert">视频无法播放</div>
         : <video
-            className={`${css.mediaPlayer} ${css.videoPlayer}`}
-            src={node.src}
-            poster={node.poster}
-            aria-label={node.alt ?? '视频'}
-            controls
-            preload="metadata"
-            playsInline
-            loop={node.loop === true}
-            muted={node.muted === true}
-            style={node.aspectRatio === undefined ? undefined : { aspectRatio: node.aspectRatio.replace(':', ' / ') }}
-            onError={() => setFailed(true)}
-          />}
+  className={`${css.mediaPlayer} ${css.videoPlayer}`}
+  src={node.src}
+  poster={node.poster}
+  aria-label={node.alt ?? '视频'}
+  controls
+  preload="metadata"
+  playsInline
+  loop={node.loop === true}
+  muted={node.muted === true}
+  style={node.aspectRatio === undefined ? undefined : { aspectRatio: node.aspectRatio.replace(':', ' / ') }}
+  onError={() => setFailed(true)}
+/>}
     </figure>
   )
 })

--- a/src/client/blocks/forms.tsx
+++ b/src/client/blocks/forms.tsx
@@ -7,8 +7,27 @@ import { useEffect, useId, useRef, useState } from 'react'
 import css from '../GenuiBlock.module.css'
 import { GENUI_LIMITS } from '../genui-runtime/index.ts'
 import type { AnswersState, GenuiBlockProps, QuestionMeta } from './state.ts'
-import type { GenuiInput, GenuiRadio, GenuiSelect, GenuiSlider, GenuiSubmit, GenuiSwitch, GenuiTextarea } from '../spec.ts'
+import type { GenuiCheckbox, GenuiInput, GenuiRadio, GenuiSelect, GenuiSlider, GenuiSubmit, GenuiSwitch, GenuiTextarea } from '../spec.ts'
 
+
+export function CheckboxNode({ node, onAction }: {
+  node: GenuiCheckbox
+  onAction?: GenuiBlockProps['onAction']
+}) {
+  const action = node.action
+  return (
+    <label className={css.checkbox}>
+      <input
+        type="checkbox"
+        defaultChecked={node.checked === true}
+        onChange={action !== undefined && onAction !== undefined
+? e => onAction(action, { type: 'checkbox', checked: e.currentTarget.checked })
+: undefined}
+      />
+      <span>{node.label}</span>
+    </label>
+  )
+}
 export function RadioNode({ node, onAction, answers }: {
   node: GenuiRadio
   onAction?: GenuiBlockProps['onAction']

--- a/src/client/blocks/layout.tsx
+++ b/src/client/blocks/layout.tsx
@@ -1,0 +1,72 @@
+/**
+ * Structural GenUI layout family. Recursive children are injected by the
+ * render dispatcher so layout components do not depend on render-node.
+ * @module @changfenhuang/dsh-genui/client/blocks/layout
+ */
+import type { ReactNode } from 'react'
+import css from '../GenuiBlock.module.css'
+import { GENUI_LIMITS } from '../genui-runtime/index.ts'
+import type { GenuiCard, GenuiCol, GenuiGrid, GenuiList, GenuiNode, GenuiRow } from '../spec.ts'
+
+type RenderChild = (node: GenuiNode, key: number) => ReactNode
+
+function isListItemNode(item: GenuiList['items'][number]): item is GenuiNode {
+  return typeof item === 'object' && item !== null && 'type' in item
+}
+
+export function RowNode({ node, renderChild }: { node: GenuiRow; renderChild: RenderChild }): ReactNode {
+  return (
+    <div className={css.row + (node.wrap ? ` ${css.wrap}` : '')}>
+      {node.items.map((child, i) => renderChild(child, i))}
+      {node.spacer && <div className={css.spacer} />}
+    </div>
+  )
+}
+
+export function ColNode({ node, renderChild }: { node: GenuiCol; renderChild: RenderChild }): ReactNode {
+  return (
+    <div className={css.col} style={node.gap !== undefined ? { gap: `${node.gap}px` } : undefined}>
+      {node.items.map((child, i) => renderChild(child, i))}
+    </div>
+  )
+}
+
+export function GridNode({ node, renderChild }: { node: GenuiGrid; renderChild: RenderChild }): ReactNode {
+  return (
+    <div className={css.grid} style={{ gridTemplateColumns: `repeat(${Math.max(1, node.cols)}, minmax(0, 1fr))` }}>
+      {node.items.map((child, i) => renderChild(child, i))}
+    </div>
+  )
+}
+
+export function CardNode({ node, renderChild }: { node: GenuiCard; renderChild: RenderChild }): ReactNode {
+  return (
+    <div className={css.card}>
+      {node.title !== undefined && <div className={css.cardTitle}>{node.title}</div>}
+      {node.items.map((child, i) => renderChild(child, i))}
+    </div>
+  )
+}
+
+export function DividerNode(): ReactNode {
+  return <hr className={css.divider} />
+}
+
+export function SpacerNode(): ReactNode {
+  return <div className={css.spacer} />
+}
+
+export function ListNode({ node, renderChild }: { node: GenuiList; renderChild: RenderChild }): ReactNode {
+  const items = node.items.slice(0, GENUI_LIMITS.maxListItems)
+  return (
+    <div className={css.list}>
+      {items.map((item, i) => (
+        <div key={i} className={css.li}>
+{isListItemNode(item)
+  ? renderChild(item, i)
+  : <><span className={css.liTitle}>{typeof item === 'string' ? item : item.title}</span>{typeof item !== 'string' && item.desc !== undefined && <span className={css.liDesc}>{item.desc}</span>}</>}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/client/blocks/render-node.tsx
+++ b/src/client/blocks/render-node.tsx
@@ -1,27 +1,52 @@
 /**
  * The recursive render dispatcher: maps the white-listed GenuiNode union to
- * concrete components. Leaf cases render inline; compound families live in
- * the sibling block modules. Depth-guarded against pathological specs.
+ * concrete block implementations. Rendering details live in sibling modules;
+ * this file owns dispatch, recursion wiring, the depth guard, and custom
+ * renderer fallback.
  * @module @changfenhuang/dsh-genui/client/blocks/render-node
  */
-import { type ReactNode, type ComponentType } from 'react'
+import { cloneElement, isValidElement, type ComponentType, type ReactNode } from 'react'
 import * as primitives from '@deepseek-ai/dsh-client-ui-primitives'
-import css from '../GenuiBlock.module.css'
 import { GENUI_LIMITS } from '../genui-runtime/index.ts'
-import type { GenuiList, GenuiNode } from '../spec.ts'
+import type { GenuiNode } from '../spec.ts'
 import type { AnswersState, GenuiBlockProps } from './state.ts'
-import { AudioNode, avatarColor, ClickFeedbackButton, VideoNode } from './basic.tsx'
+import {
+  AudioNode,
+  AvatarNode as renderAvatarNode,
+  BadgeNode as renderBadgeNode,
+  ButtonNode as renderButtonNode,
+  LinkNode as renderLinkNode,
+  ProgressNode as renderProgressNode,
+  StatNode as renderStatNode,
+  TextNode as renderTextNode,
+  VideoNode,
+} from './basic.tsx'
 import { ChartNode, TableNode } from './charts.tsx'
 import {
-  InputNode, RadioNode, SelectNode, SliderNode, SubmitNode, SwitchNode, TextareaNode,
+  CheckboxNode as renderCheckboxNode,
+  InputNode,
+  RadioNode,
+  SelectNode,
+  SliderNode,
+  SubmitNode,
+  SwitchNode,
+  TextareaNode,
 } from './forms.tsx'
+import {
+  CardNode as renderCardNode,
+  ColNode as renderColNode,
+  DividerNode as renderDividerNode,
+  GridNode as renderGridNode,
+  ListNode as renderListNode,
+  RowNode as renderRowNode,
+  SpacerNode as renderSpacerNode,
+} from './layout.tsx'
 import {
   AccordionNode, BreadcrumbNode, CalloutNode, CodeNode, CopyNode, DiffNode, FileTreeNode, JsonNode, KeyValueNode,
   MermaidNode, PlotNode, QuizNode, Scene3DNode, StepsNode, TabsNode, TimelineNode,
 } from './advanced.tsx'
 import { DiagramNode } from './diagram/index.tsx'
 import { ImageNode } from './image.tsx'
-
 import { EChartNode } from '../EChartNode.tsx'
 
 /** Custom node data shape (declared locally: pristine hosts export no type). */
@@ -43,8 +68,14 @@ type HostGenuiExt = {
 }
 const getGenuiComponent = (primitives as unknown as HostGenuiExt).getGenuiComponent
 
-function isListItemNode(item: GenuiList['items'][number]): item is GenuiNode {
-  return typeof item === 'object' && item !== null && 'type' in item
+/**
+ * The renderer functions extracted from the old inline switch stay ordinary
+ * function calls rather than becoming new React component boundaries. The key
+ * is restored on their returned root element so reconciliation matches the
+ * previous inline JSX tree.
+ */
+function withKey(node: ReactNode, key: number): ReactNode {
+  return isValidElement(node) ? cloneElement(node, { key }) : node
 }
 
 export function renderNode(
@@ -60,161 +91,37 @@ export function renderNode(
   // GenuiBlock use and plugin-registered custom renderers.
   if (depth > GENUI_LIMITS.maxDepth) return null
 
+  const renderChild = (child: GenuiNode, childKey: number): ReactNode =>
+    renderNode(child, childKey, onAction, depth + 1, answers)
+  // Preserve the existing tabs/accordion depth semantics: render-node used
+  // to pass depth + 1 into those components and they added one more level.
+  const renderNestedChild = (child: GenuiNode, childKey: number): ReactNode =>
+    renderNode(child, childKey, onAction, depth + 2, answers)
+
   switch (node.type) {
-    case 'text': {
-      const size = node.size ?? 'body'
-      return (
-        <div key={key} className={`${css.text} ${css[size]}` + (node.center ? ` ${css.center}` : '')}>
-          {node.content}
-        </div>
-      )
-    }
-    case 'row': {
-      return (
-        <div key={key} className={css.row + (node.wrap ? ` ${css.wrap}` : '')}>
-          {node.items.map((c, i) => renderNode(c, i, onAction, depth + 1, answers))}
-          {node.spacer && <div className={css.spacer} />}
-        </div>
-      )
-    }
-    case 'col': {
-      return (
-        <div key={key} className={css.col} style={node.gap !== undefined ? { gap: `${node.gap}px` } : undefined}>
-          {node.items.map((c, i) => renderNode(c, i, onAction, depth + 1, answers))}
-        </div>
-      )
-    }
-    case 'grid': {
-      return (
-        <div key={key} className={css.grid} style={{ gridTemplateColumns: `repeat(${Math.max(1, node.cols)}, minmax(0, 1fr))` }}>
-          {node.items.map((c, i) => renderNode(c, i, onAction, depth + 1, answers))}
-        </div>
-      )
-    }
-    case 'card': {
-      return (
-        <div key={key} className={css.card}>
-          {node.title !== undefined && <div className={css.cardTitle}>{node.title}</div>}
-          {node.items.map((c, i) => renderNode(c, i, onAction, depth + 1, answers))}
-        </div>
-      )
-    }
-    case 'button': {
-      const tone = node.tone ?? ''
-      const cls = `${css.button} ${css[tone] || ''}` + (node.full ? ` ${css.full}` : '') + (node.small ? ` ${css.small}` : '')
-      const action = node.action
-      // A button without an action (or without an action provider) is a
-      // display-only control: render it DISABLED so the affordance is honest
-      // — clickable-looking dead buttons were the top complaint in the field.
-      const interactive = action !== undefined && onAction !== undefined
-      return (
-        <ClickFeedbackButton
-          key={key}
-          className={cls}
-          disabled={!interactive}
-          onClick={interactive ? () => onAction(action, { type: 'button', label: node.label }) : undefined}
-        >
-          {node.icon !== undefined && <span aria-hidden>{node.icon} </span>}
-          {node.label}
-        </ClickFeedbackButton>
-      )
-    }
+    case 'text': return withKey(renderTextNode({ node }), key)
+    case 'row': return withKey(renderRowNode({ node, renderChild }), key)
+    case 'col': return withKey(renderColNode({ node, renderChild }), key)
+    case 'grid': return withKey(renderGridNode({ node, renderChild }), key)
+    case 'card': return withKey(renderCardNode({ node, renderChild }), key)
+    case 'button': return withKey(renderButtonNode({ node, onAction }), key)
     case 'input': return <InputNode key={key} node={node} onAction={onAction} answers={answers} />
     case 'select': return <SelectNode key={key} node={node} onAction={onAction} answers={answers} />
-    case 'checkbox': {
-      const action = node.action
-      return (
-        <label key={key} className={css.checkbox}>
-          <input
-            type="checkbox"
-            defaultChecked={node.checked === true}
-            onChange={action !== undefined && onAction !== undefined
-              ? e => onAction(action, { type: 'checkbox', checked: e.currentTarget.checked })
-              : undefined}
-          />
-          <span>{node.label}</span>
-        </label>
-      )
-    }
-    case 'link': {
-      // Honest affordance: with a whitelisted href this is a REAL anchor;
-      // without one it is plain styled text (a dead clickable-looking button
-      // was the same complaint class as the disabled-button fix).
-      const href = node.href
-      return href !== undefined
-        ? <a key={key} className={css.link} href={href} target="_blank" rel="noopener noreferrer">{node.label}</a>
-        : <span key={key} className={css.linkText}>{node.label}</span>
-    }
+    case 'checkbox': return withKey(renderCheckboxNode({ node, onAction }), key)
+    case 'link': return withKey(renderLinkNode({ node }), key)
     case 'image': return <ImageNode key={`${key}:${node.src}`} node={node} />
     case 'audio': return <AudioNode key={`${key}:${node.src}`} node={node} />
     case 'video': return <VideoNode key={`${key}:${node.src}`} node={node} />
-    case 'badge': {
-      const tone = node.tone ?? ''
-      return (
-        <span key={key} className={`${css.badge} ${css[tone] || ''}`}>
-          {node.icon !== undefined && <span aria-hidden>{node.icon} </span>}
-          {node.label}
-        </span>
-      )
-    }
-    case 'stat': {
-      const down = node.delta !== undefined && node.delta.startsWith('-')
-      return (
-        <div key={key} className={css.stat}>
-          <span className={css.statLabel}>{node.label}</span>
-          <span className={css.statValue}>{node.value}</span>
-          {node.delta !== undefined && <span className={`${css.statDelta} ${down ? css.down : css.up}`}>{node.delta}</span>}
-        </div>
-      )
-    }
-    case 'progress': {
-      const v = Math.max(0, Math.min(100, Number(node.value) || 0))
-      return (
-        <div
-          key={key}
-          className={css.progress}
-          role="progressbar"
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={v}
-          aria-label={node.label ?? node.valueLabel ?? undefined}
-        >
-          {(node.label !== undefined || node.valueLabel !== undefined) && (
-            <div className={css.progressRow}>
-              <span>{node.label}</span>
-              {node.valueLabel !== undefined && <span>{node.valueLabel}</span>}
-            </div>
-          )}
-          <div className={css.track}><div className={css.fill} style={{ width: `${v}%` }} /></div>
-        </div>
-      )
-    }
-    case 'divider': return <hr key={key} className={css.divider} />
-    case 'list': {
-      const items = node.items.slice(0, GENUI_LIMITS.maxListItems)
-      return (
-        <div key={key} className={css.list}>
-          {items.map((item, i) => (
-            <div key={i} className={css.li}>
-              {isListItemNode(item)
-                ? renderNode(item, i, onAction, depth + 1, answers)
-                : <><span className={css.liTitle}>{typeof item === 'string' ? item : item.title}</span>{typeof item !== 'string' && item.desc !== undefined && <span className={css.liDesc}>{item.desc}</span>}</>}
-            </div>
-          ))}
-        </div>
-      )
-    }
+    case 'badge': return withKey(renderBadgeNode({ node }), key)
+    case 'stat': return withKey(renderStatNode({ node }), key)
+    case 'progress': return withKey(renderProgressNode({ node }), key)
+    case 'divider': return withKey(renderDividerNode(), key)
+    case 'list': return withKey(renderListNode({ node, renderChild }), key)
     case 'table': return <TableNode key={key} node={node} />
     case 'chart': return <ChartNode key={key} chart={node} />
-    case 'tabs': return <TabsNode key={key} tabs={node} onAction={onAction} depth={depth + 1} answers={answers} />
-    case 'avatar': {
-      return (
-        <div key={key} className={css.avatar} style={{ background: node.color ?? avatarColor(node.name) }}>
-          {node.name.slice(0, 1).toUpperCase()}
-        </div>
-      )
-    }
-    case 'spacer': return <div key={key} className={css.spacer} />
+    case 'tabs': return <TabsNode key={key} tabs={node} renderChild={renderNestedChild} />
+    case 'avatar': return withKey(renderAvatarNode({ node }), key)
+    case 'spacer': return withKey(renderSpacerNode(), key)
     case 'plot': return <PlotNode key={key} plot={node} />
     case 'callout': return <CalloutNode key={key} node={node} />
     case 'steps': return <StepsNode key={key} steps={node} />
@@ -227,7 +134,7 @@ export function renderNode(
     case 'switch': return <SwitchNode key={key} node={node} onAction={onAction} />
     case 'slider': return <SliderNode key={key} node={node} onAction={onAction} answers={answers} />
     case 'textarea': return <TextareaNode key={key} node={node} onAction={onAction} answers={answers} />
-    case 'accordion': return <AccordionNode key={key} node={node} onAction={onAction} depth={depth + 1} answers={answers} />
+    case 'accordion': return <AccordionNode key={key} node={node} renderChild={renderNestedChild} />
     case 'copy': return <CopyNode key={key} node={node} />
     case 'mermaid': return <MermaidNode key={key} node={node} />
     case 'scene3d': return <Scene3DNode key={key} node={node} />
@@ -236,7 +143,6 @@ export function renderNode(
     case 'breadcrumb': return <BreadcrumbNode key={key} node={node} />
     case 'quiz': return <QuizNode key={key} node={node} onAction={onAction} />
     case 'diagram': return <DiagramNode key={key} node={node} />
-
     case 'echart': return <EChartNode key={key} node={node} />
     default: {
       // Plugin-registered custom types: a plugin ships a renderer through
@@ -251,7 +157,7 @@ export function renderNode(
             key={key}
             node={custom}
             onAction={onAction}
-            renderChildren={(nodes, base) => nodes.map((c, i) => renderNode(c as GenuiNode, Number(base) + i, onAction, depth + 1, answers))}
+            renderChildren={(nodes, base) => nodes.map((child, i) => renderNode(child as GenuiNode, Number(base) + i, onAction, depth + 1, answers))}
           />
         )
       }
@@ -259,5 +165,3 @@ export function renderNode(
     }
   }
 }
-
-/* ---------------- v1.1 nodes ---------------- */

--- a/tests/genui-render-dispatcher.spec.tsx
+++ b/tests/genui-render-dispatcher.spec.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { renderNode } from '../src/client/blocks/render-node.tsx'
+import type { GenuiNode } from '../src/client/spec.ts'
+
+afterEach(cleanup)
+
+function layoutNode(type: 'row' | 'col'): GenuiNode {
+  return {
+    type,
+    items: [{ type: 'input', label: 'Name' }],
+  } as GenuiNode
+}
+
+function Harness({ type }: { type: 'row' | 'col' }) {
+  return <>{renderNode(layoutNode(type), 0, undefined)}</>
+}
+
+describe('render dispatcher reconciliation', () => {
+  it('preserves compatible layout host nodes and child local state', () => {
+    const view = render(<Harness type="row" />)
+    const host = view.container.firstElementChild
+    const input = view.container.querySelector('input') as HTMLInputElement
+
+    fireEvent.change(input, { target: { value: 'Alice' } })
+    expect(input.value).toBe('Alice')
+
+    view.rerender(<Harness type="col" />)
+
+    expect(view.container.firstElementChild).toBe(host)
+    expect((view.container.querySelector('input') as HTMLInputElement).value).toBe('Alice')
+  })
+})


### PR DESCRIPTION
## 改动

- 保留 `renderNode()` 的 `switch` 分发模型，将其中的完整 JSX 实现迁移到职责所属模块
- 将 text / button / link / badge / stat / progress / avatar 等 leaf renderer 收敛到 `blocks/basic.tsx`
- 新增 `blocks/layout.tsx`，承载 row / col / grid / card / list / divider / spacer 等结构节点
- 将 checkbox renderer 移入 `blocks/forms.tsx`
- `render-node.tsx` 只保留 dispatcher、递归 wiring、depth guard 与 custom renderer fallback
- Tabs / Accordion 改为注入 `renderChild`，移除 `advanced.tsx -> render-node.tsx` 的运行时反向依赖

## 模块边界

```text
render-node.tsx
├── basic.tsx
├── layout.tsx
├── forms.tsx
├── charts.tsx
├── advanced.tsx
└── diagram/
```

`render-node.tsx` 仍使用 `switch`，没有引入 renderer map。

递归由 dispatcher 统一持有，具体 renderer 通过 callback 接收子节点渲染能力。

## 范围

这是一次纯结构重构，不修改：

- CSS / 样式
- schema / normalize / diagnostics
- repair / validation 行为
- action payload
- key 语义
- ARIA 属性
- resource limit / clamp
- custom renderer fallback

普通 layout child 仍使用 `depth + 1`。

Tabs / Accordion 保留原有实际 `depth + 2` 语义，本 PR 不顺手修正既有行为。

## 验证

- 重构前基线测试：49 个 test files passed，479 tests passed
- 重构后完整 `pnpm run check` 通过
- 确认 `basic.tsx` / `layout.tsx` / `forms.tsx` / `advanced.tsx` 不再运行时 import `render-node.tsx`
- `git diff --check` 通过
- 最终分支基于已合并的 #108，仅包含 1 个 commit / 5 个文件