### PR TITLE
fix: prioritize persisted input values over spec defaults

### DIFF
--- a/src/client/blocks/forms.tsx
+++ b/src/client/blocks/forms.tsx
@@ -396,11 +396,11 @@ export function InputNode({ node, onAction, answers }: {
   const action = node.action
   const id = node.id
   const secret = node.inputType === 'password'
-  // Initial value: spec default, else durable state (restored after refresh).
-  // Secrets restore as blank: a password that survives a refresh would be a
-  // stored secret, which is exactly what the boundary forbids.
+  const restored = !secret && id !== undefined ? answers?.fields[id] : undefined
+  // Initial value: durable state wins over the spec default. Secrets always
+  // restore as blank so a password can never survive a refresh.
   const [value, setValue] = useState<string>(() =>
-    secret ? '' : (node.value ?? (id !== undefined ? answers?.fields[id] ?? '' : '')))
+    secret ? '' : (restored ?? node.value ?? ''))
   // Last value actually DELIVERED to the model: blur only sends when the
   // value changed since the last delivery (a focus-in/focus-out with no edit
   // used to fire a pointless action round trip). Seeded with the mount value
@@ -413,12 +413,12 @@ export function InputNode({ node, onAction, answers }: {
     }
   }
   const ime = useImeComposing()
-  // Field invariant: a spec-provided non-blank default registers at mount.
+  // Register a non-blank spec default only when no durable value already exists.
   const mounted = useRef(false)
   useEffect(() => {
     if (mounted.current) return
     mounted.current = true
-    if (!secret && id !== undefined && node.value !== undefined && node.value.trim() !== '') {
+    if (!secret && id !== undefined && restored === undefined && node.value !== undefined && node.value.trim() !== '') {
       answers?.setField(id, node.value)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/tests/input-durable-value-priority.spec.tsx
+++ b/tests/input-durable-value-priority.spec.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { hasFenceRegistry } from './setup'
+import { GenuiActionContext } from '../src/client/action-context.ts'
+import { GENUI_ACTION_DEBOUNCE_MS } from '../src/client/GenuiBlock.tsx'
+import { GenuiBlock } from '../src/client/GenuiBlock.tsx'
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  localStorage.clear()
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+function renderBlock(
+  spec: unknown,
+  stateKey: string,
+  onAction: (action: string, payload: Record<string, unknown>) => void,
+) {
+  return render(
+    <GenuiActionContext.Provider value={onAction}>
+      <GenuiBlock spec={spec as never} stateKey={stateKey} />
+    </GenuiActionContext.Provider>,
+  )
+}
+
+describe.skipIf(!hasFenceRegistry)('input durable value priority', () => {
+  it('restored durable value wins over the spec default after remount', () => {
+    const stateKey = 'input-durable-value-priority'
+    const spec = {
+      items: [
+        { type: 'input', label: '名称', id: 'name', value: '默认值' },
+        { type: 'submit', label: '发送', action: 'send' },
+      ],
+    }
+    const onAction = vi.fn()
+
+    renderBlock(spec, stateKey, onAction)
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input.value).toBe('默认值')
+
+    fireEvent.change(input, { target: { value: '用户值' } })
+    vi.advanceTimersByTime(400)
+
+    cleanup()
+    renderBlock(spec, stateKey, onAction)
+
+    const restored = screen.getByRole('textbox') as HTMLInputElement
+    expect(restored.value).toBe('用户值')
+
+    fireEvent.click(screen.getByRole('button', { name: '发送' }))
+    vi.advanceTimersByTime(GENUI_ACTION_DEBOUNCE_MS)
+    expect(onAction).toHaveBeenCalledWith('send', expect.objectContaining({
+      fields: { name: '用户值' },
+    }))
+  })
+})


### PR DESCRIPTION
## 变更说明

修复 `InputNode` 中持久化字段值与 spec 默认值的优先级问题。

此前当 input 同时包含 `id` 和 `value` 时，即使用户修改后的值已经持久化，组件重新挂载后仍会优先使用 `node.value`，并在 mount 阶段再次将默认值写回 `fields`，导致用户已保存的值被覆盖。

本 PR 调整为：

- 对普通 input，优先使用已持久化的 `fields[id]`
- 仅在不存在持久化值时使用 `node.value`
- mount 时仅在不存在持久化值的情况下注册 spec 默认值
- 保持 password input 的现有安全行为不变

## 测试

新增回归测试，覆盖以下场景：

1. input 带有 spec 默认值
2. 用户修改字段值并完成持久化
3. 组件重新挂载
4. 已持久化的用户值优先于 spec 默认值
5. submit payload 中继续使用恢复后的用户值

该修改也使 `InputNode` 的恢复语义与现有 `SelectNode` / `SliderNode` 更一致。

## 关联

为 #103 中 `inputType: "color"` 的字段持久化场景提供正确的基础行为。