### PR TITLE
feat(checkbox): support grouped multi-select aggregation

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -56,18 +56,18 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 - **秘密禁令**：不得索取或生成密码、API Key、访问令牌、恢复码等秘密输入；遇到此类需求直接拒绝并解释
 - input: `{"type":"input","label":"...","placeholder":"...","inputType":"text|email","value":"...","action":"name"?,"id":"field-id"?}` — action 在失焦**和回车**时触发（回车带 `submit:true`）；**blur 仅值有变化才发送**（聚焦又离开不产生空往返）；payload 带 `id` 帮模型定位字段；带 `id` 的值刷新后保留、并被 submit 收集进 `fields`
 - select: `{"type":"select","label":"...","options":["...","..."],"selected":下标?,"action":"pick"?,"id":"field-id"?}` — `selected` 预选某选项（缺省显示「请选择…」占位，不静默预选第一项）；带 `id` 的选择跨刷新保留并进 submit 的 `fields`
-- checkbox: `{"type":"checkbox","label":"...","checked":true?,"action":"toggle"?}`
+- checkbox: `{"type":"checkbox","label":"...","checked":true?,"action":"toggle"?,"group":"组名"?}` — 默认保持逐次 `action` 行为；**加 `group` 进入多选聚合模式**：同组 checkbox 可反复勾选/取消，变化只在本地记录、不发逐次 action，兄弟 `submit` 一次性把该组已选 label 作为字符串数组放进 `answers`（例如 `{"styles":["极简","线稿"]}`）
 - slider: `{"type":"slider","label":"...","min":0,"max":100,"step":1,"value":n?,"action":"name"?,"id":"field-id"?}` — 数值表单滑块：实时显示数值；带 `id` 跨刷新保留并进 submit 的 `fields`（拖拽经防抖合并成一次 action）
 - radio: `{"type":"radio","label":"...","options":["...","..."],"selected":n?,"action":"pick"?}` — 单选；**加 `"group":"题目名"` 进入聚合模式**：选择只本地记录、不发往返；**加 `"answer":正确下标或标签` + `"explanation":"解析"` 后，交卷在本地判卷**
 - link: `{"type":"link","label":"...","href":"https://..."?}` — 仅 http(s)/mailto 协议被接受；无 `href` 时渲染为纯文本样式（不会假装可点）
-- submit: `{"type":"submit","label":"交卷","action":"grade","groups":["q1","q2","q3"],"resetAction":"redo"?}` — 交卷按钮：**题目带 answer 时点击本地立即判卷**（得分 + 每题 ✓/✗ + 解析，零往返），并锁定题目，点「重新作答」本地重置（`resetAction` 可选通知你）；**只有题目都没带 answer 时才**汇总成一次 `[genui-action]`（payload: `{answers:{q1:选项A,...},fields:{id:值},total,answered}`，`fields` 收集所有带 `id` 的输入）；`groups` 列出的题全部答完才可点
+- submit: `{"type":"submit","label":"交卷","action":"grade","groups":["q1","styles"],"resetAction":"redo"?}` — 聚合按钮：纯 radio 且题目带 `answer` 时仍本地立即判卷（得分 + 每题 ✓/✗ + 解析，零往返）；其余聚合场景一次发送 `[genui-action]`，payload 为 `{answers:{q1:选项A,styles:[选项1,选项2]},fields:{id:值},total,answered}`。`groups` 中每个 radio 必须已选择、每个 checkbox 组必须至少勾选一项才可提交
 - switch: `{"type":"switch","label":"...","checked":true?,"action":"toggle"?}`
 - textarea: `{"type":"textarea","label":"...","placeholder":"...","rows":n?,"value":"...","action":"save"?,"id":"field-id"?}` — action 在失焦和 **Ctrl/Cmd+Enter** 时触发；blur 仅值有变化才发送；带 `id` 的值刷新后保留
 - tabs: `{"type":"tabs","tabs":[{"label":"...","items":[...]}]}`
 - accordion: `{"type":"accordion","items":[{"title":"...","items":[...]}]}`
 - copy: `{"type":"copy","label":"复制","text":"..."}`
 
-**状态持久化（v2.7）**：答案、交卷锁定、输入值按「会话 + 内容指纹」自动保存——用户刷新页面/重开会话，同一块 UI 的状态原样恢复；你重渲染**相同内容**会保留用户状态，渲染**新内容**（换题等）自动从头开始。
+**状态持久化（v2.7）**：radio 答案、checkbox 分组选择、交卷锁定、输入值按「会话 + 内容指纹」自动保存——用户刷新页面/重开会话，同一块 UI 的状态原样恢复；你重渲染**相同内容**会保留用户状态，渲染**新内容**（换题等）自动从头开始。
 
 **卷子模式（多道选择题）**：每题一个 radio（带唯一 `group` + `answer` + `explanation`），最后放一个 submit（`groups` 列出全部题号）——用户全部选完点交卷，**分数和对错当场在 UI 里出现**，不用等你。只有换新题/进阶建议才发 action。不要每题单独发 action（会刷屏）。
 
@@ -97,7 +97,7 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 | 两个方案 / 选项对比 | `table`、`tabs`、`diff` |
 | 教学 / 自测 / 判断题 | `quiz` |
 | 数学函数 / 曲线关系 | `plot`（可带参数滑块、动画） |
-| 需要用户操作 / 筛选 / 反馈 | `button`、`input`、`select`、`radio`、`switch`、`tabs` |
+| 需要用户操作 / 筛选 / 反馈 | `button`、`input`、`select`、`checkbox`、`radio`、`switch`、`tabs` |
 | 3D 物体 / 空间布局 | `scene3d` |
 
 **别用的情况**：一句话能说清的事、纯闲聊、用户明确说不要 UI、以及"为了炫技硬塞"——组件服务内容，不是内容服务组件。

--- a/src/client/GenuiBlock.tsx
+++ b/src/client/GenuiBlock.tsx
@@ -74,15 +74,13 @@ function specEquivalent(a: GenuiSpec, b: GenuiSpec): boolean {
 function GenuiBlockInstance({ spec, stateKey }: GenuiBlockProps) {
   const gap = spec.gap ?? 16
   const onAction = useDebouncedAction(useGenuiAction())
-  // v2.5/v2.6 answers registry: grouped radios record selections + question
-  // metadata here; `submit` nodes grade locally (locked until 重新作答) or
-  // collect into one action. Block-local state survives re-renders (streaming
-  // settle, panel updates) — selections persist while the block is mounted.
-  // v2.7 durability: with a stateKey the state ALSO survives refresh/reopen —
-  // loaded once at mount (seed for re-renders of the same content) and saved
-  // on every change.
+  // Grouped radios and grouped checkboxes record their local selections here;
+  // `submit` either grades radio-only papers locally or aggregates all form
+  // state into one action. Block-local state survives streaming/panel
+  // re-renders, and with a stateKey it also survives refresh/reopen.
   const [persisted] = useState(() => (stateKey === undefined ? null : loadBlockState(stateKey)))
   const [answers, setAnswers] = useState<Record<string, string>>(persisted?.answers ?? {})
+  const [multiAnswers, setMultiAnswers] = useState<Record<string, string[]>>(persisted?.multiAnswers ?? {})
   const [fields, setFields] = useState<Record<string, string>>(persisted?.fields ?? {})
   const [meta, setMeta] = useState<Record<string, QuestionMeta>>({})
   const [locked, setLocked] = useState(persisted?.locked === true)
@@ -93,6 +91,22 @@ function GenuiBlockInstance({ spec, stateKey }: GenuiBlockProps) {
   const [secretFields, setSecretFields] = useState<ReadonlySet<string>>(new Set())
   const setAnswer = useCallback((group: string, choice: string) => {
     setAnswers(prev => (prev[group] === choice ? prev : { ...prev, [group]: choice }))
+  }, [])
+  const setMultiAnswer = useCallback((group: string, choice: string, checked: boolean) => {
+    setMultiAnswers(prev => {
+      const current = prev[group] ?? []
+      const next = checked
+        ? current.includes(choice) ? current : [...current, choice]
+        : current.filter(item => item !== choice)
+      const hadGroup = Object.prototype.hasOwnProperty.call(prev, group)
+      if (hadGroup && next.length === current.length && next.every((item, index) => item === current[index])) {
+        return prev
+      }
+      // Keep an explicit empty array: it distinguishes "user cleared this
+      // group" from "group never had local state", so checked defaults do not
+      // reappear after a refresh.
+      return { ...prev, [group]: next }
+    })
   }, [])
   const setField = useCallback((id: string, value: string) => {
     // Field invariant: a blank (trim-empty) value leaves the shared registry.
@@ -119,15 +133,16 @@ function GenuiBlockInstance({ spec, stateKey }: GenuiBlockProps) {
   }, [])
   const clear = useCallback(() => {
     setAnswers({})
+    setMultiAnswers({})
     setLocked(false)
     setRound(r => r + 1) // radios remount (key carries the round) with clean selections
   }, [])
   const answersState = useMemo<AnswersState>(
     () => ({
-      answers, fields, secretFields, meta, locked, round,
-      setAnswer, setField, registerSecretField, registerMeta, clear, setLocked,
+      answers, multiAnswers, fields, secretFields, meta, locked, round,
+      setAnswer, setMultiAnswer, setField, registerSecretField, registerMeta, clear, setLocked,
     }),
-    [answers, fields, secretFields, meta, locked, round, setAnswer, setField, registerSecretField, registerMeta, clear],
+    [answers, multiAnswers, fields, secretFields, meta, locked, round, setAnswer, setMultiAnswer, setField, registerSecretField, registerMeta, clear],
   )
   // Achievement telemetry: every emitted action counts as one interaction
   // (the debounced emit fires once per real user action).
@@ -148,12 +163,13 @@ function GenuiBlockInstance({ spec, stateKey }: GenuiBlockProps) {
       )
       saveBlockState(stateKey, {
         answers,
+        ...(Object.keys(multiAnswers).length > 0 ? { multiAnswers } : {}),
         locked,
         ...(Object.keys(safeFields).length > 0 ? { fields: safeFields } : {}),
       })
     }, 300)
     return () => clearTimeout(timer)
-  }, [stateKey, answers, locked, fields, secretFields])
+  }, [stateKey, answers, multiAnswers, locked, fields, secretFields])
   // Achievement telemetry (0.9.5): the store dedupes by spec fingerprint, so
   // streaming re-renders and replays count once per distinct content.
   useEffect(() => {

--- a/src/client/blocks/checkbox.tsx
+++ b/src/client/blocks/checkbox.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import css from '../GenuiBlock.module.css'
+import type { GenuiCheckbox } from '../spec.ts'
+import type { AnswersState, GenuiBlockProps } from './state.ts'
+
+/**
+ * Checkbox with two backwards-compatible modes:
+ *
+ * - no `group`: legacy local toggle + optional per-click action;
+ * - with `group`: local-only multi-select state collected by a sibling submit.
+ *
+ * A persisted group key wins over `checked`, including an explicit empty
+ * array. This lets a user clear every default-checked option without those
+ * defaults reappearing after refresh.
+ */
+export function CheckboxNode({ node, onAction, answers }: {
+  node: GenuiCheckbox
+  onAction?: GenuiBlockProps['onAction']
+  answers?: AnswersState | undefined
+}) {
+  const group = node.group
+  const grouped = group !== undefined
+  const hasRecordedGroup = group !== undefined
+    && Object.prototype.hasOwnProperty.call(answers?.multiAnswers ?? {}, group)
+  const recorded = group === undefined ? undefined : answers?.multiAnswers[group]
+  const initialChecked = hasRecordedGroup
+    ? Array.isArray(recorded) && recorded.includes(node.label)
+    : node.checked === true
+  const [checked, setChecked] = useState(initialChecked)
+
+  useEffect(() => {
+    if (group === undefined || node.checked !== true || hasRecordedGroup) return
+    // Model-provided defaults are real initial selections, but never override
+    // a restored user choice (including an explicitly empty group).
+    answers?.setMultiAnswer(group, node.label, true)
+    // answers is intentionally omitted: the callbacks are stable and a
+    // registry update should not re-register the same default.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [group, node.checked, node.label, hasRecordedGroup])
+
+  return (
+    <label className={css.checkbox}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={e => {
+          const next = e.currentTarget.checked
+          setChecked(next)
+          if (grouped) {
+            // Aggregation mode: update local multi-answer state only.
+            answers?.setMultiAnswer(group, node.label, next)
+          } else if (node.action !== undefined && onAction !== undefined) {
+            onAction(node.action, { type: 'checkbox', checked: next })
+          }
+        }}
+      />
+      <span>{node.label}</span>
+    </label>
+  )
+}

--- a/src/client/blocks/checkbox.tsx
+++ b/src/client/blocks/checkbox.tsx
@@ -23,10 +23,10 @@ export function CheckboxNode({ node, onAction, answers }: {
   const hasRecordedGroup = group !== undefined
     && Object.prototype.hasOwnProperty.call(answers?.multiAnswers ?? {}, group)
   const recorded = group === undefined ? undefined : answers?.multiAnswers[group]
-  const initialChecked = hasRecordedGroup
+  const groupChecked = hasRecordedGroup
     ? Array.isArray(recorded) && recorded.includes(node.label)
     : node.checked === true
-  const [checked, setChecked] = useState(initialChecked)
+  const [checked, setChecked] = useState(node.checked === true)
 
   useEffect(() => {
     if (group === undefined || node.checked !== true || hasRecordedGroup) return
@@ -42,7 +42,7 @@ export function CheckboxNode({ node, onAction, answers }: {
     <label className={css.checkbox}>
       <input
         type="checkbox"
-        checked={checked}
+        checked={grouped ? groupChecked : checked}
         onChange={e => {
           const next = e.currentTarget.checked
           setChecked(next)

--- a/src/client/blocks/forms.tsx
+++ b/src/client/blocks/forms.tsx
@@ -82,20 +82,16 @@ export function correctLabelOf(m: QuestionMeta): string | undefined {
   return m.answer
 }
 
-/** Submit: the "交卷" control of a grouped-radio block. LOCAL-FIRST (v2.6):
- * when at least one question carries `answer` data the click grades IN PLACE
- * — score, per-question right/wrong, explanations — with zero model round
- * trip, and locks the questions until 重新作答 resets them. Only when NO
- * question has answers does it fall back to firing ONE action
- * (`{type:'submit', answers, total, answered}`). Disabled until the
- * selection criteria are met (all listed groups answered, or ≥1 answer
- * without a group list); the hint shows the progress. */
+/** Submit: collect grouped radio and checkbox answers. Radio-only scopes keep
+ * LOCAL-FIRST grading; when checkbox selections participate, the click falls
+ * back to the aggregation action so multi-select data is never discarded. */
 export function SubmitNode({ node, onAction, answers }: {
   node: GenuiSubmit
   onAction?: GenuiBlockProps['onAction']
   answers?: AnswersState | undefined
 }) {
   const recorded = answers?.answers ?? {}
+  const multiRecorded = answers?.multiAnswers ?? {}
   const fields = answers?.fields ?? {}
   const meta = answers?.meta ?? {}
   const expected = node.groups
@@ -104,21 +100,35 @@ export function SubmitNode({ node, onAction, answers }: {
   const filledFields = Object.fromEntries(
     Object.entries(fields).filter(([id, v]) => v.trim() !== '' && !answers?.secretFields.has(id)),
   )
-  // Without an explicit group list, the submit counts radio answers AND
-  // filled fields — a fields-only form (inputs with id + submit) enables
-  // once any field has a value.
+  const nonEmptyMultiGroups = Object.entries(multiRecorded)
+    .filter(([, values]) => Array.isArray(values) && values.length > 0)
+    .map(([group]) => group)
+  const recordedGroups = new Set([...Object.keys(recorded), ...nonEmptyMultiGroups])
+  const hasRecordedAnswer = (group: string): boolean =>
+    recorded[group] !== undefined || (Array.isArray(multiRecorded[group]) && multiRecorded[group]!.length > 0)
+
+  // Explicit groups require at least one selected checkbox (or a radio answer)
+  // per group. Empty checkbox arrays remain durable state but are deliberately
+  // not considered "answered".
   const answered = expected === undefined
-    ? Math.max(Object.keys(recorded).length, Object.keys(filledFields).length)
-    : expected.filter(g => recorded[g] !== undefined).length
+    ? Math.max(recordedGroups.size, Object.keys(filledFields).length)
+    : expected.filter(hasRecordedAnswer).length
   const total = expected?.length ?? answered
-  const scope = expected ?? Object.keys(recorded)
-  // Local grading is possible when ANY in-scope question carries answers.
-  const canGradeLocally = scope.some(g => meta[g]?.answer !== undefined)
+  const scope = expected ?? [...recordedGroups]
+  const hasMultiInScope = scope.some(group =>
+    Array.isArray(multiRecorded[group]) && multiRecorded[group]!.length > 0,
+  )
+  // Local grading must be radio-only. Otherwise grading would consume the
+  // click and silently omit checkbox selections that need model delivery.
+  const canGradeLocally = !hasMultiInScope && scope.some(group => meta[group]?.answer !== undefined)
   const submitted = answers?.locked === true
+  const collectedAnswers: Record<string, string | string[]> = {
+    ...recorded,
+    ...multiRecorded,
+  }
   // Ready = enough answers AND the click can do something: either local
   // grading, or a real action name + provider. A submit with neither is a
-  // display-only control — honest disabled affordance (action is optional:
-  // local grading needs no round trip).
+  // display-only control — honest disabled affordance.
   const ready = answered > 0 && answered >= total
     && (canGradeLocally || (node.action !== undefined && onAction !== undefined))
 
@@ -191,7 +201,7 @@ export function SubmitNode({ node, onAction, answers }: {
             // the optional-action type honest.
             onAction(node.action, {
               type: 'submit',
-              answers: recorded,
+              answers: collectedAnswers,
               ...(Object.keys(filledFields).length > 0 ? { fields: filledFields } : {}),
               total,
               answered,

--- a/src/client/blocks/render-node.tsx
+++ b/src/client/blocks/render-node.tsx
@@ -15,6 +15,7 @@ import { ChartNode, TableNode } from './charts.tsx'
 import {
   InputNode, RadioNode, SelectNode, SliderNode, SubmitNode, SwitchNode, TextareaNode,
 } from './forms.tsx'
+import { CheckboxNode } from './checkbox.tsx'
 import {
   AccordionNode, BreadcrumbNode, CalloutNode, CodeNode, CopyNode, DiffNode, FileTreeNode, JsonNode, KeyValueNode,
   MermaidNode, PlotNode, QuizNode, Scene3DNode, StepsNode, TabsNode, TimelineNode,
@@ -121,21 +122,7 @@ export function renderNode(
     }
     case 'input': return <InputNode key={key} node={node} onAction={onAction} answers={answers} />
     case 'select': return <SelectNode key={key} node={node} onAction={onAction} answers={answers} />
-    case 'checkbox': {
-      const action = node.action
-      return (
-        <label key={key} className={css.checkbox}>
-          <input
-            type="checkbox"
-            defaultChecked={node.checked === true}
-            onChange={action !== undefined && onAction !== undefined
-              ? e => onAction(action, { type: 'checkbox', checked: e.currentTarget.checked })
-              : undefined}
-          />
-          <span>{node.label}</span>
-        </label>
-      )
-    }
+    case 'checkbox': return <CheckboxNode key={key} node={node} onAction={onAction} answers={answers} />
     case 'link': {
       // Honest affordance: with a whitelisted href this is a REAL anchor;
       // without one it is plain styled text (a dead clickable-looking button

--- a/src/client/blocks/state.ts
+++ b/src/client/blocks/state.ts
@@ -1,8 +1,8 @@
 /**
  * Shared block-level state types: the block props contract and the answers
- * registry (grouped radios → submit grading). Lives OUTSIDE GenuiBlock.tsx so
- * the per-family block modules can import the types without a cycle back
- * into the block shell.
+ * registry (grouped radios / checkboxes → submit aggregation). Lives OUTSIDE
+ * GenuiBlock.tsx so the per-family block modules can import the types without
+ * a cycle back into the block shell.
  * @module @changfenhuang/dsh-genui/client/blocks/state
  */
 import type { GenuiSpec } from '../spec.ts'
@@ -18,10 +18,11 @@ export interface GenuiBlockProps {
   onAction?: ((action: string, payload: Record<string, unknown>) => void) | undefined
   /**
    * v2.7: durable-state key (session + slot + content fingerprint). When set,
-   * interaction state (radio answers, submit lock, field values) persists to
-   * localStorage and restores on refresh / re-render of the same content.
-   * Changing this key also starts a fresh in-memory interaction-state lifetime;
-   * callers only provide stateKey — GenuiBlock owns the matching React identity.
+   * interaction state (radio answers, checkbox groups, submit lock, field
+   * values) persists to localStorage and restores on refresh / re-render of
+   * the same content. Changing this key also starts a fresh in-memory
+   * interaction-state lifetime; callers only provide stateKey — GenuiBlock
+   * owns the matching React identity.
    */
   stateKey?: string | undefined
 }
@@ -36,15 +37,17 @@ export interface QuestionMeta {
   explanation?: string | undefined
 }
 
-/** Block-wide answers registry (v2.5/v2.6): grouped radios record selections
- * and register their question metadata here; a sibling `submit` node either
- * grades IN PLACE (questions carry `answer` data) or collects everything
- * into ONE action. Lives in GenuiBlock state so re-renders keep the
- * selections, threaded down through the recursive render walk. Answers are
- * plain group → chosen-option-label strings (the display label lives in
- * QuestionMeta; localStorage stores the same string table — no migration). */
+/** Block-wide aggregation state. Grouped radios store one selected label in
+ * `answers`; grouped checkboxes store a selected-label array in
+ * `multiAnswers`. Keeping the registries separate preserves the existing
+ * radio/local-grading string contract while allowing submit to expose one
+ * unified `answers` payload (`string | string[]`). */
 export interface AnswersState {
   answers: Record<string, string>
+  /** Grouped checkbox selections. An empty array is meaningful: the user
+   * explicitly cleared the group, so model-provided `checked` defaults must
+   * not reappear after a durable restore. */
+  multiAnswers: Record<string, string[]>
   /** Field values by id (input/textarea with an `id`), collected by submit. */
   fields: Record<string, string>
   /** Field ids whose value must never be persisted or collected (secrets). */
@@ -55,6 +58,7 @@ export interface AnswersState {
   /** Bumped by every reset; radios use it as their remount key. */
   round: number
   setAnswer: (group: string, choice: string) => void
+  setMultiAnswer: (group: string, choice: string, checked: boolean) => void
   setField: (id: string, value: string) => void
   registerSecretField: (id: string) => void
   registerMeta: (group: string, meta: QuestionMeta) => void

--- a/src/client/genui-runtime/schema.ts
+++ b/src/client/genui-runtime/schema.ts
@@ -244,7 +244,7 @@ export const COMPONENT_SCHEMAS: Readonly<Record<string, ComponentSchema>> = {
     enums: { kind: CHART_KINDS },
     validator: { name: 'chart-renderability' },
   }),
-  checkbox: schema(['label'], { ...nodeFields, label: 'string', checked: 'boolean', action: 'string' }),
+  checkbox: schema(['label'], { ...nodeFields, label: 'string', checked: 'boolean', action: 'string', group: 'string' }),
   code: schema(['code'], { ...nodeFields, lang: 'string', code: 'string' }),
   col: schema(['items'], { ...nodeFields, items: 'nodes', gap: 'number' }),
   copy: schema(['text'], { ...nodeFields, label: 'string', text: 'string' }),

--- a/src/client/guard.ts
+++ b/src/client/guard.ts
@@ -270,7 +270,12 @@ function repairNode(value: unknown, ctx: RepairCtx, depth: number): GenuiNode | 
     case 'checkbox': {
       const label = str(v.label, GENUI_LIMITS.maxString)
       if (label === undefined) return null
-      return { type: 'checkbox', label, ...opt('checked', v.checked === true ? true : undefined), ...opt('action', str(v.action, 200)) }
+      return {
+        type: 'checkbox', label,
+        ...opt('checked', v.checked === true ? true : undefined),
+        ...opt('action', str(v.action, 200)),
+        ...opt('group', str(v.group, 200)),
+      }
     }
     case 'link': {
       const label = str(v.label, GENUI_LIMITS.maxString)

--- a/src/client/interaction-store.ts
+++ b/src/client/interaction-store.ts
@@ -1,6 +1,7 @@
 /**
  * Interaction-state store: durable per-block GenUI interaction state
- * (radio answers, submit lock, input/textarea values) in localStorage.
+ * (radio answers, checkbox groups, submit lock, input/textarea values) in
+ * localStorage.
  *
  * LOCAL-FIRST persistence: a ```dsh-ui block's interactive state survives
  * page refresh and session reopen because it is keyed by
@@ -10,7 +11,7 @@
  * share state because their content fingerprints differ.
  *
  * Bounded: at most MAX_BLOCKS entries, LRU-evicted on write; each block's
- * payload is small (answers map + a few field values).
+ * payload is small (answer maps + a few field values).
  * @module @changfenhuang/dsh-genui/client/interaction-store
  */
 
@@ -18,6 +19,10 @@
 export interface BlockInteractionState {
   /** group → chosen option label (radio aggregation answers). */
   answers?: Record<string, string>
+  /** group → chosen option labels (checkbox aggregation answers). Empty arrays
+   * are retained so an explicitly cleared group wins over `checked` defaults
+   * after refresh. */
+  multiAnswers?: Record<string, string[]>
   /** True after a local grading: the paper stays graded across refresh. */
   locked?: boolean
   /** field id → current value (input/textarea with an `id`). */

--- a/src/client/spec.ts
+++ b/src/client/spec.ts
@@ -139,6 +139,12 @@ export interface GenuiCheckbox {
   checked?: boolean
   /** v2: when set, interaction sends this action back to the model. */
   action?: string
+  /**
+   * Aggregation group name. When set, toggles stay local and update the
+   * block-wide multi-answer registry instead of firing the per-click action;
+   * a sibling `submit` collects the selected labels as a string array.
+   */
+  group?: string
 }
 
 export interface GenuiLink {
@@ -396,23 +402,17 @@ export interface GenuiRadio {
   explanation?: string
 }
 
-/** Submit node: collects the answers of sibling `radio` groups in this block.
- * LOCAL-FIRST: when the questions carry `answer` data the click grades IN
- * PLACE — score, per-question right/wrong, explanations — with no model
- * round trip, and locks the questions until "重新作答" resets them. Only when
- * NO question carries answers does it fall back to firing ONE action
- * (`{type:'submit', answers, total, answered}`). */
+/** Submit node: collects sibling `radio` and grouped `checkbox` answers in
+ * this block. LOCAL-FIRST grading still applies to radio-only question scopes;
+ * aggregation scopes can emit strings for radio groups and string arrays for
+ * checkbox groups in the same `answers` object. */
 export interface GenuiSubmit {
   type: 'submit'
   label: string
   /**
-   * Optional action name. Local-first: when ANY question in scope carries
-   * `answer` data the click grades IN PLACE with zero model round trip, so
-   * no action is needed — the spec stays valid without one. Only when NO
-   * question has local answers does the submit need an action to collect
-   * `{type:'submit', answers, total, answered}`; without one the button
-   * renders disabled (honest affordance). Also fired as the reset hook if
-   * `resetAction` is absent.
+   * Optional action name. Local-first: when the in-scope questions can be
+   * graded entirely locally, no action is needed. Aggregation submits require
+   * an action and emit `{type:'submit', answers, total, answered}`.
    */
   action?: string
   /**
@@ -423,9 +423,9 @@ export interface GenuiSubmit {
   resetAction?: string
   /**
    * Optional explicit group list to wait for; when absent the submit enables
-   * once at least one grouped radio has an answer. When present it stays
-   * disabled until EVERY listed group has a recorded answer (the hint shows
-   * the progress).
+   * once at least one grouped answer (or filled field) exists. When present
+   * it stays disabled until EVERY listed radio/checkbox group has a non-empty
+   * recorded answer (the hint shows the progress).
    */
   groups?: string[]
 }

--- a/tests/genui-checkbox-group.spec.tsx
+++ b/tests/genui-checkbox-group.spec.tsx
@@ -176,4 +176,25 @@ describe('checkbox group aggregation', () => {
     }]])
     expect(container.querySelector('[data-genui-grade]')).toBeNull()
   })
+  it('keeps visible selections and submitted answers aligned after a local reset', () => {
+    const actions: Array<[string, Record<string, unknown>]> = []
+    const spec: GenuiSpec = { items: [
+      { type: 'radio', label: '题目', group: 'q1', options: ['A', 'B'], answer: 'A' },
+      { type: 'submit', label: '交卷', groups: ['q1'] },
+      { type: 'checkbox', label: '附加项', group: 'extras' },
+      { type: 'submit', label: '保存附加项', action: 'save', groups: ['extras'] },
+    ] }
+    const ui = renderWithActions(spec, actions)
+    fireEvent.click(ui.getByLabelText('附加项'))
+    fireEvent.click(ui.container.querySelector('input[type="radio"]')!)
+    fireEvent.click(ui.getByRole('button', { name: '交卷' }))
+    fireEvent.click(ui.getAllByRole('button', { name: '重新作答' })[0]!)
+    expect((ui.getByLabelText('附加项') as HTMLInputElement).checked).toBe(false)
+    expect((ui.getByRole('button', { name: '保存附加项' }) as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.click(ui.getByLabelText('附加项'))
+    fireEvent.click(ui.getByRole('button', { name: '保存附加项' }))
+    vi.advanceTimersByTime(GENUI_ACTION_DEBOUNCE_MS)
+    expect(actions).toEqual([['save', { type: 'submit', answers: { extras: ['附加项'] }, total: 1, answered: 1 }]])
+  })
+
 })

--- a/tests/genui-checkbox-group.spec.tsx
+++ b/tests/genui-checkbox-group.spec.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { GenuiActionContext } from '../src/client/action-context.ts'
+import { GenuiBlock, GENUI_ACTION_DEBOUNCE_MS } from '../src/client/GenuiBlock.tsx'
+import { repairGenuiSpec, validateGenuiSpec } from '../src/client/guard.ts'
+import type { GenuiSpec } from '../src/client/spec.ts'
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  localStorage.clear()
+})
+
+function renderWithActions(
+  spec: GenuiSpec,
+  actions: Array<[string, Record<string, unknown>]>,
+  stateKey?: string,
+) {
+  return render(
+    <GenuiActionContext.Provider value={(action, payload) => actions.push([action, payload])}>
+      <GenuiBlock spec={spec} stateKey={stateKey} />
+    </GenuiActionContext.Provider>,
+  )
+}
+
+describe('checkbox group aggregation', () => {
+  it('preserves and validates checkbox.group through the guard', () => {
+    const raw = {
+      items: [{ type: 'checkbox', label: '工序示意式', group: 'fig_types' }],
+    }
+    const repaired = repairGenuiSpec(raw)
+    expect(repaired).not.toBeNull()
+    expect((repaired!.items[0] as { group?: string }).group).toBe('fig_types')
+    expect(validateGenuiSpec(raw).ok).toBe(true)
+
+    const invalid = validateGenuiSpec({
+      items: [{ type: 'checkbox', label: '工序示意式', group: 123 }],
+    })
+    expect(invalid.ok).toBe(false)
+    expect(invalid.errors.join('\n')).toContain('group')
+  })
+
+  it('keeps grouped toggles local and submits all selected labels once', () => {
+    const actions: Array<[string, Record<string, unknown>]> = []
+    const spec: GenuiSpec = {
+      items: [
+        { type: 'checkbox', label: '工序示意式', group: 'fig_types', action: 'ignored-toggle' },
+        { type: 'checkbox', label: '节点大样式', group: 'fig_types' },
+        { type: 'checkbox', label: '透视效果图', group: 'fig_types' },
+        { type: 'submit', label: '锁定', action: 'submit_fig', groups: ['fig_types'] },
+      ],
+    }
+    const { container } = renderWithActions(spec, actions)
+    const boxes = container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
+    const submit = container.querySelector<HTMLButtonElement>('[class*="submitRow"] button')!
+
+    expect(submit.disabled).toBe(true)
+    fireEvent.click(boxes[0]!)
+    fireEvent.click(boxes[1]!)
+    vi.advanceTimersByTime(GENUI_ACTION_DEBOUNCE_MS)
+    expect(actions).toHaveLength(0)
+    expect(boxes[0]!.checked).toBe(true)
+    expect(boxes[1]!.checked).toBe(true)
+    expect(submit.disabled).toBe(false)
+
+    fireEvent.click(submit)
+    vi.advanceTimersByTime(GENUI_ACTION_DEBOUNCE_MS)
+    expect(actions).toEqual([['submit_fig', {
+      type: 'submit',
+      answers: { fig_types: ['工序示意式', '节点大样式'] },
+      total: 1,
+      answered: 1,
+    }]])
+  })
+
+  it('supports cancelling selections and disables submit after clearing the group', () => {
+    const actions: Array<[string, Record<string, unknown>]> = []
+    const spec: GenuiSpec = {
+      items: [
+        { type: 'checkbox', label: 'A', group: 'styles' },
+        { type: 'checkbox', label: 'B', group: 'styles' },
+        { type: 'submit', label: '锁定', action: 'save', groups: ['styles'] },
+      ],
+    }
+    const { container } = renderWithActions(spec, actions)
+    const boxes = container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
+    const submit = container.querySelector<HTMLButtonElement>('[class*="submitRow"] button')!
+
+    fireEvent.click(boxes[0]!)
+    fireEvent.click(boxes[1]!)
+    fireEvent.click(boxes[0]!)
+    expect(submit.disabled).toBe(false)
+
+    fireEvent.click(submit)
+    vi.advanceTimersByTime(GENUI_ACTION_DEBOUNCE_MS)
+    expect(actions).toEqual([['save', {
+      type: 'submit',
+      answers: { styles: ['B'] },
+      total: 1,
+      answered: 1,
+    }]])
+
+    fireEvent.click(boxes[1]!)
+    expect(submit.disabled).toBe(true)
+    expect(container.querySelector('[class*="submitHint"]')?.textContent).toContain('已选 0/1')
+  })
+
+  it('lets an explicitly cleared durable group override checked defaults', () => {
+    const actions: Array<[string, Record<string, unknown>]> = []
+    const spec: GenuiSpec = {
+      items: [
+        { type: 'checkbox', label: '默认风格', group: 'styles', checked: true },
+        { type: 'submit', label: '锁定', action: 'save', groups: ['styles'] },
+      ],
+    }
+
+    const first = renderWithActions(spec, actions, 'checkbox-group:durable')
+    const firstBox = first.container.querySelector<HTMLInputElement>('input[type="checkbox"]')!
+    const firstSubmit = first.container.querySelector<HTMLButtonElement>('[class*="submitRow"] button')!
+    expect(firstBox.checked).toBe(true)
+    expect(firstSubmit.disabled).toBe(false)
+
+    fireEvent.click(firstBox)
+    expect(firstBox.checked).toBe(false)
+    expect(firstSubmit.disabled).toBe(true)
+    vi.advanceTimersByTime(300)
+    first.unmount()
+
+    const second = renderWithActions(spec, actions, 'checkbox-group:durable')
+    const restoredBox = second.container.querySelector<HTMLInputElement>('input[type="checkbox"]')!
+    const restoredSubmit = second.container.querySelector<HTMLButtonElement>('[class*="submitRow"] button')!
+    expect(restoredBox.checked).toBe(false)
+    expect(restoredSubmit.disabled).toBe(true)
+  })
+
+  it('keeps the legacy per-click action when group is absent', () => {
+    const actions: Array<[string, Record<string, unknown>]> = []
+    const spec: GenuiSpec = {
+      items: [{ type: 'checkbox', label: '启用', action: 'toggle' }],
+    }
+    const { container } = renderWithActions(spec, actions)
+    const box = container.querySelector<HTMLInputElement>('input[type="checkbox"]')!
+
+    fireEvent.click(box)
+    vi.advanceTimersByTime(GENUI_ACTION_DEBOUNCE_MS)
+    expect(actions).toEqual([['toggle', { type: 'checkbox', checked: true }]])
+  })
+
+  it('falls back to aggregation when a submit scope mixes local grading and checkbox groups', () => {
+    const actions: Array<[string, Record<string, unknown>]> = []
+    const spec: GenuiSpec = {
+      items: [
+        { type: 'radio', label: '单选题', group: 'q1', options: ['A', 'B'], answer: 'B' },
+        { type: 'checkbox', label: '附加项', group: 'extras' },
+        { type: 'submit', label: '提交', action: 'save', groups: ['q1', 'extras'] },
+      ],
+    }
+    const { container } = renderWithActions(spec, actions)
+    fireEvent.click(container.querySelectorAll<HTMLInputElement>('[role="radiogroup"] input')[1]!)
+    fireEvent.click(container.querySelector<HTMLInputElement>('input[type="checkbox"]')!)
+    const submit = container.querySelector<HTMLButtonElement>('[class*="submitRow"] button')!
+    expect(submit.disabled).toBe(false)
+
+    fireEvent.click(submit)
+    vi.advanceTimersByTime(GENUI_ACTION_DEBOUNCE_MS)
+    expect(actions).toEqual([['save', {
+      type: 'submit',
+      answers: { q1: 'B', extras: ['附加项'] },
+      total: 2,
+      answered: 2,
+    }]])
+    expect(container.querySelector('[data-genui-grade]')).toBeNull()
+  })
+})


### PR DESCRIPTION
## 变更说明

为 `checkbox` 增加基于 `group` 的本地多选聚合能力，解决 #105 中多选场景下需要「可取消 + 本地静默 + submit 一次性回传」的问题。

此前：

- `radio` 已支持 `group + submit` 聚合，但只能单选
- `checkbox` 虽然支持多选和取消，但只能通过逐次 `action` 回传
- 因此多选过程中每次勾选 / 取消都会触发模型往返

本 PR 将现有 `radio.group` 的聚合语义扩展到 `checkbox`。

## 实现方式

### checkbox group 聚合

`checkbox` 新增可选的 `group`：

```json
{
  "type": "checkbox",
  "label": "工序示意式",
  "group": "fig_types"
}
```

当存在 `group` 时：

- 勾选和取消仅更新本地状态
- 不触发逐次 `action`
- 同一 group 下可以同时选择多个 checkbox
- 再次点击已选项可以取消

未设置 `group` 时，继续保持现有 checkbox 的逐次 `action` 行为，兼容原有用法。

### submit 一次性聚合

兄弟 `submit` 可以继续使用现有 `groups`：

```json
{
  "type": "submit",
  "label": "锁定",
  "action": "submit_fig",
  "groups": ["fig_types"]
}
```

提交时复用现有 `answers` payload，不新增顶层 `multi` 字段。

radio group 仍然是字符串：

```json
{
  "q1": "B"
}
```

checkbox group 使用字符串数组：

```json
{
  "fig_types": [
    "工序示意式",
    "节点大样式"
  ]
}
```

因此混合场景下的 payload 可以直接表示为：

```json
{
  "type": "submit",
  "answers": {
    "q1": "B",
    "fig_types": [
      "工序示意式",
      "节点大样式"
    ]
  },
  "total": 2,
  "answered": 2
}
```

### 状态与持久化

新增独立的 checkbox 多选状态 registry，避免修改现有 radio 的 `Record<string, string>` 语义。

同时支持：

- 多选状态随 block state 持久化
- `checked: true` 可以作为初始默认选择
- 用户显式取消全部选择后会保留空数组状态
- 刷新后不会因为 `checked: true` 再次恢复已经被用户取消的默认项

### 本地判卷兼容

原有 radio-only 本地判卷行为保持不变。

当一个 submit scope 同时包含 checkbox 聚合数据时，会走正常的 action 聚合提交，避免本地 grading 提前消费点击而导致 checkbox 结果没有回传。

## 协议与文档

同步更新：

- `GenuiCheckbox.group`
- runtime component schema
- guard / repair
- block interaction state
- durable interaction store
- `SKILL.md`

## 测试

新增 checkbox group 回归测试，覆盖：

- guard / schema 保留并校验 `checkbox.group`
- grouped checkbox 点击保持本地静默
- 同组多项选择
- 已选项再次点击取消
- submit 一次性提交 `string[]`
- 清空最后一个选项后 submit 恢复禁用
- `checked: true` 默认值与持久化状态
- 显式清空状态跨刷新保持
- 无 group checkbox 保持原有逐次 action
- radio + checkbox 混合聚合

相同代码树已通过：

- Node.js 22 / 24 `pnpm run check`
- pack verification
- smoke e2e
- Windows Node.js 22 / 24 build + pack

Closes #105