### PR TITLE
fix(diff): support DiffBlock labels on newer DSH versions

### DIFF
--- a/src/client/blocks/advanced.tsx
+++ b/src/client/blocks/advanced.tsx
@@ -87,9 +87,38 @@ export const PlotNode = memo(function PlotNode({ plot }: { plot: GenuiPlot }) {
   )
 })
 
+type DiffBlockLabelsCompat = {
+  copy: string
+  copied: string
+  collapseAria: string
+  expandAria: (hidden: number) => string
+  collapse: string
+  expand: (hidden: number) => string
+  files: (count: number) => string
+}
+
+/**
+ * dsh 0.1.2-rc.1 moved DiffBlock chrome text into a required `labels` prop.
+ * Keep the old dsh-genui wording here so one renderer works with both the
+ * legacy primitive (which simply ignores this extra prop) and newer hosts.
+ */
+const DIFF_BLOCK_LABELS: DiffBlockLabelsCompat = {
+  copy: '复制',
+  copied: '复制成功',
+  collapseAria: '收起差异',
+  expandAria: hidden => `展开其余 ${hidden} 行差异`,
+  collapse: '收起',
+  expand: hidden => `… 其余 ${hidden} 行`,
+  files: count => `${count} file${count === 1 ? '' : 's'}`,
+}
+
 /** Diff: 收编 dsh DiffBlock (same path/oldText/newText shape as DiffHunk). */
 export const DiffNode = memo(function DiffNode({ node }: { node: GenuiDiff }) {
-  return <DiffBlock diffs={node.diffs} />
+  // Spread from a named value on purpose: old peer typings do not declare
+  // `labels`, while new peer typings require it. Structurally this satisfies
+  // both without pinning dsh-genui to one host release.
+  const props = { diffs: node.diffs, labels: DIFF_BLOCK_LABELS }
+  return <DiffBlock {...props} />
 })
 
 /** Json: 收编 dsh JsonTree. */

--- a/tests/genui-diff-compat.spec.tsx
+++ b/tests/genui-diff-compat.spec.tsx
@@ -11,8 +11,20 @@ async function importDiffNodeWithMock() {
     const actual = await vi.importActual<typeof import('@deepseek-ai/dsh-client-ui-primitives')>(
       '@deepseek-ai/dsh-client-ui-primitives',
     )
+
+    const getGenuiComponent = (
+      actual as typeof actual & {
+        getGenuiComponent?: unknown
+      }
+    ).getGenuiComponent
+
     return {
       ...actual,
+
+      // Vitest mock 必须显式声明这个可选 host export。
+      // 老版 host 为 undefined，新版 host 则保留真实实现。
+      getGenuiComponent,
+
       DiffBlock: (props: unknown) => {
         diffBlockSpy(props)
         return null

--- a/tests/genui-diff-compat.spec.tsx
+++ b/tests/genui-diff-compat.spec.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GenuiDiff } from '../src/client/spec.ts'
+
+const { diffBlockSpy } = vi.hoisted(() => ({ diffBlockSpy: vi.fn() }))
+
+vi.mock('@deepseek-ai/dsh-client-ui-primitives', async importOriginal => {
+  const actual = await importOriginal<typeof import('@deepseek-ai/dsh-client-ui-primitives')>()
+  return {
+    ...actual,
+    DiffBlock: (props: unknown) => {
+      diffBlockSpy(props)
+      return null
+    },
+  }
+})
+
+import { DiffNode } from '../src/client/blocks/advanced.tsx'
+
+afterEach(() => {
+  cleanup()
+  diffBlockSpy.mockClear()
+})
+
+describe('DiffBlock host compatibility', () => {
+  it('passes the labels required by newer dsh primitives', () => {
+    const node = {
+      type: 'diff',
+      diffs: [{ path: 'a.txt', oldText: 'x', newText: 'y' }],
+    } satisfies GenuiDiff
+
+    render(<DiffNode node={node} />)
+
+    expect(diffBlockSpy).toHaveBeenCalled()
+    const props = diffBlockSpy.mock.calls[0]![0] as {
+      diffs: GenuiDiff['diffs']
+      labels?: {
+        copy: string
+        copied: string
+        collapseAria: string
+        expandAria: (hidden: number) => string
+        collapse: string
+        expand: (hidden: number) => string
+        files: (count: number) => string
+      }
+    }
+
+    expect(props.diffs).toEqual(node.diffs)
+    expect(props.labels).toBeDefined()
+    expect(props.labels?.copy).toBe('复制')
+    expect(props.labels?.copied).toBe('复制成功')
+    expect(props.labels?.expandAria(3)).toBe('展开其余 3 行差异')
+    expect(props.labels?.expand(3)).toBe('… 其余 3 行')
+    expect(props.labels?.files(1)).toBe('1 file')
+    expect(props.labels?.files(2)).toBe('2 files')
+  })
+})

--- a/tests/genui-diff-compat.spec.tsx
+++ b/tests/genui-diff-compat.spec.tsx
@@ -3,20 +3,24 @@ import { cleanup, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { GenuiDiff } from '../src/client/spec.ts'
 
-const { diffBlockSpy } = vi.hoisted(() => ({ diffBlockSpy: vi.fn() }))
+const diffBlockSpy = vi.fn()
 
-vi.mock('@deepseek-ai/dsh-client-ui-primitives', async importOriginal => {
-  const actual = await importOriginal<typeof import('@deepseek-ai/dsh-client-ui-primitives')>()
-  return {
-    ...actual,
-    DiffBlock: (props: unknown) => {
-      diffBlockSpy(props)
-      return null
-    },
-  }
-})
-
-import { DiffNode } from '../src/client/blocks/advanced.tsx'
+async function importDiffNodeWithMock() {
+  vi.resetModules()
+  vi.doMock('@deepseek-ai/dsh-client-ui-primitives', async () => {
+    const actual = await vi.importActual<typeof import('@deepseek-ai/dsh-client-ui-primitives')>(
+      '@deepseek-ai/dsh-client-ui-primitives',
+    )
+    return {
+      ...actual,
+      DiffBlock: (props: unknown) => {
+        diffBlockSpy(props)
+        return null
+      },
+    }
+  })
+  return import('../src/client/blocks/advanced.tsx')
+}
 
 afterEach(() => {
   cleanup()
@@ -24,7 +28,8 @@ afterEach(() => {
 })
 
 describe('DiffBlock host compatibility', () => {
-  it('passes the labels required by newer dsh primitives', () => {
+  it('passes the labels required by newer dsh primitives', async () => {
+    const { DiffNode } = await importDiffNodeWithMock()
     const node = {
       type: 'diff',
       diffs: [{ path: 'a.txt', oldText: 'x', newText: 'y' }],


### PR DESCRIPTION
## 变更说明

修复 #113。

DSH `0.1.2-rc.1` 中，`@deepseek-ai/dsh-client-ui-primitives` 的 `DiffBlock` 将界面文案抽取为必传的 `labels` 参数。

`dsh-genui` 当前仍然只传入：

```tsx
<DiffBlock diffs={node.diffs} />
```

因此在新版 DSH 中渲染 `diff` 组件时，`labels` 为 `undefined`，最终触发：

```text
Cannot read properties of undefined (reading 'copy')
```

本 PR 为 `DiffBlock` 补充完整的 labels 配置，同时通过对象展开方式传递 props，以兼容旧版和新版 DSH primitive。

主要改动：

- 为 `DiffBlock` 补充 `copy`、`copied`、`collapseAria`、`expandAria`、`collapse`、`expand`、`files` 文案
- 保持旧版 DSH 下的现有 diff 展示文案
- 兼容新版 `DiffBlock` 必传 `labels` 的接口
- 新增回归测试，验证 diff renderer 会正确传递新版所需 labels

## 测试

- `pnpm test` 通过
- `pnpm check` 通过
- 已在实际 DSH 环境中人工验证 `diff` 组件可正常渲染

Closes #113