### PR TITLE
style(flow): timeline / tabs / accordion 观感打磨

### DIFF
--- a/src/client/GenuiBlock.module.css
+++ b/src/client/GenuiBlock.module.css
@@ -638,23 +638,27 @@
 }
 
 .tabs { display: flex; flex-direction: column; gap: var(--dsl-g-gap-md); }
-.tabBar { display: flex; gap: var(--dsl-g-gap-xs); border-bottom: 1px solid var(--dsl-g-border); }
+.tabBar { display: flex; gap: 2px; border-bottom: 1px solid var(--dsl-g-border); }
 .tab {
   background: transparent;
   border: none;
-  color: var(--dsw-alias-label-tertiary);
+  /* Inactive tabs were tertiary (barely readable); secondary + a hover wash
+     keeps the hierarchy while staying legible. */
+  color: var(--dsw-alias-label-secondary);
   font-size: var(--dsl-g-font-title);
   font-weight: 600;
   font-family: inherit;
-  padding: 6px 12px;
+  padding: 8px 14px;
   border-bottom: 2px solid transparent;
+  border-radius: var(--dsl-g-radius-sm) var(--dsl-g-radius-sm) 0 0;
   margin-bottom: -1px;
   cursor: pointer;
   line-height: 1.5;
-  transition: color 0.15s, border-bottom-color 0.15s;
+  transition: color 0.15s, background 0.15s, border-bottom-color 0.15s;
 }
-.tab:hover { color: var(--dsw-alias-label-secondary); }
-.tabActive { color: var(--dsw-alias-label-primary); border-bottom-color: var(--dsl-g-accent); }
+.tab:hover { color: var(--dsw-alias-label-primary); background: var(--dsl-g-hover); }
+.tabActive { color: var(--dsw-alias-label-primary); font-weight: 650; border-bottom-color: var(--dsl-g-accent); }
+.tab:focus-visible { outline: 2px solid var(--dsl-g-accent); outline-offset: -2px; }
 
 .avatar {
   width: 32px;
@@ -1156,6 +1160,7 @@
   border: 1px solid var(--dsl-g-border);
   border-radius: var(--dsl-g-radius-surface);
   overflow: hidden;
+  background: var(--dsw-alias-bg-layer-1, transparent);
 }
 .accItem { border-bottom: 1px solid var(--dsl-g-border); }
 .accItem:last-child { border-bottom: none; }
@@ -1165,26 +1170,35 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--dsl-g-gap-sm);
-  background: var(--dsw-alias-bg-layer-1);
+  background: transparent;
   border: none;
   color: var(--dsw-alias-label-primary);
-  padding: 10px 14px;
-  font-size: var(--dsl-g-font-title);
+  padding: 12px 15px;
+  font-size: var(--dsl-g-font-body);
   font-weight: 600;
   cursor: pointer;
   font-family: inherit;
   line-height: 1.5;
+  text-align: left;
   transition: background 0.15s, color 0.15s;
 }
-.accHead:hover { background: color-mix(in srgb, var(--dsw-alias-label-primary) 5%, var(--dsw-alias-bg-layer-1)); }
-.accHead:active { color: var(--dsl-g-accent); }
-.accChevron { color: var(--dsw-alias-label-tertiary); transition: transform 0.2s; }
+.accHead:hover { background: var(--dsl-g-hover); }
+.accHead[aria-expanded="true"] { border-bottom: 1px solid var(--dsl-g-border); }
+/* One chevron that rotates, instead of swapping glyphs: the state change reads
+   as motion, and the closed/open shapes stay consistent. */
+.accChevron {
+  flex-shrink: 0;
+  color: var(--dsw-alias-label-tertiary);
+  font-size: 11px;
+  transition: transform 0.2s ease;
+}
+.accChevron[data-open="true"] { transform: rotate(90deg); }
 .accBody {
-  padding: var(--dsl-g-gap-md) 14px;
+  padding: 12px 15px 14px;
   display: flex;
   flex-direction: column;
   gap: var(--dsl-g-gap-sm);
-  background: var(--dsw-alias-bg-base, #17171a);
+  background: color-mix(in srgb, var(--dsw-alias-label-primary) 2%, transparent);
 }
 
 /* ---------- copy chip ---------- */
@@ -1280,22 +1294,34 @@
 
 .timeline { display: flex; flex-direction: column; }
 .tlItem { display: flex; gap: var(--dsl-g-gap-md); }
-.tlRail { display: flex; flex-direction: column; align-items: center; width: 12px; flex-shrink: 0; }
+.tlRail { display: flex; flex-direction: column; align-items: center; width: 10px; flex-shrink: 0; }
 .tlDot {
-  width: 10px;
-  height: 10px;
+  width: 9px;
+  height: 9px;
   border-radius: 50%;
-  margin-top: 4px;
+  margin-top: 5px;
   flex-shrink: 0;
   background: var(--dsl-g-accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--dsl-g-accent) var(--dsl-g-tint-strong), transparent);
+  /* A soft halo instead of a hard ring: the dot reads as a marker on the rail
+     rather than a bullet stuck to the text. */
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--dsl-g-accent) 16%, transparent);
+  transition: transform 0.15s ease;
 }
-.tlLine { flex: 1; width: 2px; margin: 2px 0; background: var(--dsl-g-border); }
-.tlBody { padding-bottom: var(--dsl-g-gap-lg); flex: 1; min-width: 0; }
+.tlItem:hover .tlDot { transform: scale(1.15); }
+.tlLine { flex: 1; width: 1px; margin: 4px 0 0; background: var(--dsl-g-border); }
+.tlBody { padding-bottom: 18px; flex: 1; min-width: 0; }
+.tlItem:last-child .tlBody { padding-bottom: 0; }
 .tlHead { display: flex; align-items: baseline; gap: var(--dsl-g-gap-md); }
-.tlTitle { font-size: var(--dsl-g-font-title); font-weight: 600; color: var(--dsw-alias-label-primary); line-height: 1.5; }
-.tlTime { font-size: var(--dsl-g-font-meta); color: var(--dsw-alias-label-tertiary); margin-left: auto; white-space: nowrap; }
-.tlDesc { font-size: var(--dsl-g-font-title); color: var(--dsw-alias-label-secondary); margin-top: 2px; line-height: 1.5; }
+.tlTitle { font-size: var(--dsl-g-font-body); font-weight: 650; color: var(--dsw-alias-label-primary); line-height: 1.45; }
+.tlTime {
+  margin-left: auto;
+  white-space: nowrap;
+  font-family: var(--dsl-g-font-mono);
+  font-size: var(--dsl-g-font-data);
+  color: var(--dsw-alias-label-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+.tlDesc { font-size: var(--dsl-g-font-title); color: var(--dsw-alias-label-secondary); margin-top: 3px; line-height: 1.55; }
 
 /* ---------- file tree ---------- */
 

--- a/src/client/blocks/advanced.tsx
+++ b/src/client/blocks/advanced.tsx
@@ -202,7 +202,7 @@ export function AccordionNode({ node, onAction, depth = 0, answers }: {
             onClick={() => setOpen(open === i ? null : i)}
           >
             <span className={css.accTitle}>{item.title}</span>
-            <span className={css.accChevron}>{open === i ? '▾' : '▸'}</span>
+            <span className={css.accChevron} data-open={open === i} aria-hidden>▸</span>
           </button>
           {open === i && (
             <div className={css.accBody} id={`${uid}-body-${i}`} aria-labelledby={`${uid}-head-${i}`}>


### PR DESCRIPTION
承接 #123 的「流程与结构」一段：\n\n- **tabs**：未选中从三级色改二级色（原来几乎不可读），悬停给底色与主色，选中加粗 + 强调色下划线，补 focus-visible。\n- **timeline**：轨道 2px→1px；圆点 10px→9px，硬环换柔和光晕，悬停轻微放大；标题 13.5→14.5px/650；时间等宽右对齐；最后一项去掉多余底部间距。\n- **accordion**：容器带底色、头行悬停 wash、展开时头行下方出分隔线；chevron 由换字形改为同一箭头旋转；内容区改极淡底色。\n\n验证：tsc 通过 · 518 测试通过 · 构建通过 · 视觉 E2E 全绿（含文件树纵向布局与图表 tooltip 断言）。