### PR TITLE
feat(binding): 表格/图表/列表可就地筛选（零往返）

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -34,7 +34,7 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 - audio: `{"type":"audio","src":"/mmx-files/result.mp3","alt":"语音结果","loop":true?}` — 原生控制条；用户主动播放，不自动播放；仅 http(s) 或同源相对地址
 - video: `{"type":"video","src":"/mmx-files/result.mp4","alt":"视频结果","poster":"/mmx-files/poster.jpg"?,"loop":true?,"muted":true?,"aspectRatio":"16:9|4:3|1:1|9:16"?}` — 原生播放/音量/全屏控制；不自动播放
 - list: `{"type":"list","items":["..."] 或 [{"title":"...","desc":"..."}] 或嵌套节点(如 {"type":"badge","label":"TS"})}` — 行内可嵌节点（计入节点预算）
-- table: `{"type":"table","columns":["..."],"rows":[["...","..."]],"types":["text|num|delta|bar|badge"]?,"details":[[...]]?,"total":true?}` — 表头点击本地排序（升/降/还原，零往返）；数值感知：千分位（`1,234`）、`k/m/b`、`万/亿`、`%`、货币符号都能按真实数值比较，纯数值列自动右对齐；**带符号单元格自动着色**（`+12.4%` 绿、`-3` 红，无需额外字段）；`types` 可按列指定 `bar`（0-100 内联进度条）、`ring`（0-100 小环）、`spark`（单元格写 `"3,5,4,8"` 画微趋势线）、`badge`（胶囊标签）、`delta`（强制涨跌色）、`num`（强制右对齐）、`index`（行号）、`group`（首列当分组标题：该行只有第一格有内容时渲染成跨列小标题）；`"total":true` 追加合计行（数值列自动求和）；**`"details"` 与 rows 同序**，第 i 项是该行展开后的内容（可放任意组件，`null` = 该行不可展开）——首列出现 chevron，点开在整行下方展开明细，适合「主表 + 明细」
+- table: `{"type":"table","columns":["..."],"rows":[["...","..."]],"types":["text|num|delta|bar|badge"]?,"details":[[...]]?,"total":true?}` — 表头点击本地排序（升/降/还原，零往返）；数值感知：千分位（`1,234`）、`k/m/b`、`万/亿`、`%`、货币符号都能按真实数值比较，纯数值列自动右对齐；**带符号单元格自动着色**（`+12.4%` 绿、`-3` 红，无需额外字段）；`types` 可按列指定 `bar`（0-100 内联进度条）、`ring`（0-100 小环）、`spark`（单元格写 `"3,5,4,8"` 画微趋势线）、`badge`（胶囊标签）、`delta`（强制涨跌色）、`num`（强制右对齐）、`index`（行号）、`group`（首列当分组标题：该行只有第一格有内容时渲染成跨列小标题）；`"total":true` 追加合计行（数值列自动求和）；**`"filter":"输入框id"`**：把表格和某个 input/select 绑定，读者输入即时过滤（`filterColumn` 可限定列）——数据多时**默认就该配一个**；**`"sortField":"下拉id"`** 用下拉的值（列名）排序；**`"details"` 与 rows 同序**，第 i 项是该行展开后的内容（可放任意组件，`null` = 该行不可展开）——首列出现 chevron，点开在整行下方展开明细，适合「主表 + 明细」
 - keyvalue: `{"type":"keyvalue","pairs":[{"key":"...","value":"..."}]}`
 - timeline: `{"type":"timeline","items":[{"title":"...","desc":"...","time":"..."}]}`
 - file-tree: `{"type":"file-tree","items":[{"name":"...","type":"file|dir","children":[...]?}]}` — 目录行可点击折叠/展开（本地，零往返）
@@ -93,6 +93,7 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 | 重点强调 / 警告 / 注意事项 | `callout`（info/success/warning/error）、`badge`、`stat` |
 | 数据对比 / 趋势 / 占比 | `chart`（bars/line/donut）、`echart`（ECharts 全功能）、`table` |
 | 关键指标数字 / 进度状态 | `stat`、`progress`、`badge` |
+| 数据多、需要读者自己找 | `input`（id）+ `table`/`chart`/`list` 的 `filter` 绑定 |
 | 流程 / 步骤 / 阶段 / 时间线 | `steps`、`timeline`、`mermaid`（flowchart/sequence/gantt） |
 | 架构 / 系统拓扑 / 数据流 / 品牌图 | `diagram`（编辑级，27 种类型；自动布局需求才用 `mermaid`） |
 | 目录 / 文件结构 / 层级关系 | `file-tree`、`mermaid`、`accordion` |

--- a/scripts/e2e-visual.mts
+++ b/scripts/e2e-visual.mts
@@ -280,6 +280,23 @@ try {
   }
   log('✓ 流式骨架：出现 → settle 后换成真组件')
 
+  // ── 本地筛选（数据绑定）验证 ─────────────────────────────────────────────
+  // 绑定筛选是纯客户端行为：输入框的值直接过滤表格，不发任何请求。断言它在真实
+  // 浏览器里确实生效，且清空后恢复。
+  const filterInput = page.getByPlaceholder('输入关键字即时过滤下表')
+  if (await filterInput.count() > 0) {
+    const before = await page.locator('table tbody tr').count()
+    await filterInput.fill('搜索')
+    await page.waitForTimeout(400)
+    const after = await page.locator('table tbody tr').count()
+    if (!(after < before)) throw new Error(`绑定筛选未生效（${before} → ${after} 行）`)
+    await filterInput.fill('')
+    await page.waitForTimeout(300)
+    const restored = await page.locator('table tbody tr').count()
+    if (restored !== before) throw new Error(`清空筛选后未恢复（期望 ${before}，实际 ${restored}）`)
+    log(`✓ 本地筛选：${before} → ${after} → ${restored} 行`)
+  }
+
   // ── 文件树布局验证 ───────────────────────────────────────────────────────
   // jsdom 没有布局，只有真实浏览器能证明「子节点在父节点下方」——这条断言钉住
   // 曾经的 bug：子节点被塞进父行的 flex 容器，整棵树横着排成一行。

--- a/src/client/GenuiBlock.module.css
+++ b/src/client/GenuiBlock.module.css
@@ -862,6 +862,22 @@
   opacity: 0.6;
 }
 
+/* Live-filter feedback: how many rows survived the bound control. */
+.filterRow td {
+  padding: 7px var(--dsl-g-gap-md);
+  border-top: 1px solid var(--dsl-g-border);
+  color: var(--dsw-alias-label-secondary);
+  font-size: var(--dsl-g-font-meta);
+  font-variant-numeric: tabular-nums;
+  background: transparent;
+}
+.filterHint {
+  display: block;
+  padding-top: 6px;
+  color: var(--dsw-alias-label-secondary);
+  font-size: var(--dsl-g-font-meta);
+}
+
 /* Master-detail rows (table.details): a chevron in the first cell opens a
    full-width panel underneath, so a table can drill down without leaving the
    page or opening a modal. */

--- a/src/client/blocks/charts.tsx
+++ b/src/client/blocks/charts.tsx
@@ -10,7 +10,7 @@
  * true zero line so negative values are drawn, not clamped away.
  * @module @changfenhuang/dsh-genui/client/blocks/charts
  */
-import { Fragment, memo, useCallback, useId, useLayoutEffect, useRef, useState } from 'react'
+import { Fragment, memo, useCallback, useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { MouseEvent as ReactMouseEvent, ReactNode, RefObject } from 'react'
 import css from '../GenuiBlock.module.css'
 import { GENUI_LIMITS } from '../genui-runtime/index.ts'
@@ -143,8 +143,12 @@ function CellBar({ cell }: { cell: string | number }) {
   )
 }
 
-export const TableNode = memo(function TableNode({ node, renderDetail }: {
+export const TableNode = memo(function TableNode({ node, renderDetail, filterValue, sortValue }: {
   node: GenuiTable
+  /** Live value of `node.filter`: substring-match rows locally. */
+  filterValue?: string | undefined
+  /** Live value of `node.sortField`: a column header to sort by. */
+  sortValue?: string | undefined
   /** Renders a row's detail nodes. Supplied by render-node so the table never
    *  has to import the renderer back (import cycle). */
   renderDetail?: ((items: NonNullable<GenuiTable['details']>[number] & object[]) => ReactNode) | undefined
@@ -175,9 +179,23 @@ export const TableNode = memo(function TableNode({ node, renderDetail }: {
     groupMode && String(row[0] ?? '').trim() !== ''
     && row.slice(1).every(cell => String(cell ?? '').trim() === '')
 
+  // Local filtering (bound control): the model ships the full data set once and
+  // the reader narrows it live — no round trip, no re-generation.
+  const needle = filterValue?.trim().toLowerCase()
+  const filtered = needle === undefined || needle === ''
+    ? rows.map((row, index) => ({ row, index }))
+    : rows.map((row, index) => ({ row, index })).filter(({ row }) => {
+      const cells = node.filterColumn === undefined
+        ? row
+        : [row[node.filterColumn]]
+      return cells.some(cell => String(cell ?? '').toLowerCase().includes(needle))
+    })
+  const visibleRows = filtered.map(entry => entry.row)
+  const hiddenCount = rows.length - visibleRows.length
+
   interface Section { header: { row: GenuiTable['rows'][number]; index: number } | null; children: Array<{ row: GenuiTable['rows'][number]; index: number }> }
   const sections: Section[] = []
-  rows.forEach((row, index) => {
+  visibleRows.forEach((row, index) => {
     if (isGroupRow(row)) { sections.push({ header: { row, index }, children: [] }); return }
     if (sections.length === 0 || sections[sections.length - 1]!.header === null) {
       if (sections.length === 0) sections.push({ header: null, children: [] })
@@ -187,18 +205,19 @@ export const TableNode = memo(function TableNode({ node, renderDetail }: {
 
   // Sorting keeps sections intact: each section's children sort among
   // themselves, so a grouped table can never scramble its own structure.
+  // `sortField` is a select whose value is a column header: apply it as the
+  // active sort (a click on the header still overrides it).
+  const boundSortCol = sortValue === undefined ? -1 : columns.indexOf(sortValue)
+  const effectiveSort = sort !== null ? sort : (boundSortCol >= 0 ? { col: boundSortCol, dir: 1 as const } : null)
+
   const sortedSections = sections.map(section => ({
     header: section.header,
-    children: sort === null
+    children: effectiveSort === null
       ? section.children
-      : [...section.children].sort((a, b) => compare(a.row, b.row, sort.col, sort.dir)),
+      : [...section.children].sort((a, b) => compare(a.row, b.row, effectiveSort.col, effectiveSort.dir)),
   }))
 
-  const flatSorted = sortedSections.flatMap(section => [
-    ...(section.header === null ? [] : [section.header.row]),
-    ...section.children.map(child => child.row),
-  ])
-  const numeric = numericColumns(flatSorted, columns.length)
+  const numeric = numericColumns(visibleRows, columns.length)
   const toggleSection = (index: number): void => {
     setCollapsed(prev => {
       const next = new Set(prev)
@@ -224,7 +243,7 @@ export const TableNode = memo(function TableNode({ node, renderDetail }: {
   const totals = columns.map((_c, j) => {
     if (!numeric[j]) return null
     let sum = 0
-    for (const row of rows) {
+    for (const row of visibleRows) {
       if (isGroupRow(row)) continue
       const n = parseSortableNumber(row[j])
       if (Number.isFinite(n)) sum += n
@@ -340,6 +359,13 @@ export const TableNode = memo(function TableNode({ node, renderDetail }: {
             )
           })}
         </tbody>
+        {hiddenCount > 0 && (
+          <tfoot>
+            <tr className={css.filterRow}>
+              <td colSpan={columns.length}>筛选后 {visibleRows.length} / {rows.length} 行</td>
+            </tr>
+          </tfoot>
+        )}
         {hasTotals && (
           <tfoot>
             <tr>
@@ -464,12 +490,30 @@ function YAxis({ ticks, lo, span }: { ticks: number[]; lo: number; span: number 
 }
 
 /** Chart: bars (default), line (trend), or donut (share); multi-series bars via `series`. */
-export const ChartNode = memo(function ChartNode({ chart }: { chart: GenuiChart }) {
-  const kind = chart.kind ?? 'bars'
-  if (kind === 'donut') return <DonutNode chart={chart} />
-  if (kind === 'line') return <LineChartNode chart={chart} />
-  return <BarsNode chart={chart} />
+export const ChartNode = memo(function ChartNode({ chart, filterValue }: {
+  chart: GenuiChart
+  /** Live value of the control bound via `chart.filter`; keeps matching
+   *  categories only (label substring), so a chart is explorable locally. */
+  filterValue?: string | undefined
+}) {
+  const filtered = useMemo(() => applyChartFilter(chart, filterValue), [chart, filterValue])
+  const kind = filtered.kind ?? 'bars'
+  if (kind === 'donut') return <DonutNode chart={filtered} />
+  if (kind === 'line') return <LineChartNode chart={filtered} />
+  return <BarsNode chart={filtered} />
 })
+
+/** Keep the categories whose label matches the bound filter (case-insensitive).
+ *  Bars/donut filter `data`, line filters each series' points. */
+function applyChartFilter(chart: GenuiChart, filterValue: string | undefined): GenuiChart {
+  const needle = filterValue?.trim().toLowerCase()
+  if (needle === undefined || needle === '') return chart
+  const keep = (datum: { label: string }): boolean => datum.label.toLowerCase().includes(needle)
+  const data = chart.data.filter(keep)
+  if (chart.series === undefined) return data.length === chart.data.length ? chart : { ...chart, data }
+  const series = chart.series.map(entry => ({ ...entry, data: entry.data.filter(keep) }))
+  return { ...chart, data, series }
+}
 
 /** Bars: one column per datum (grouped bars when `series` is present).
  *  Single-series bars render against a true zero line, so negative values

--- a/src/client/blocks/render-node.tsx
+++ b/src/client/blocks/render-node.tsx
@@ -105,6 +105,22 @@ function Sparkline({ values }: { values: number[] }) {
   )
 }
 
+/** Live value of a bound control (`node.filter` / `node.sortField`): the field id
+ *  resolves against the block's shared field registry, so typing in an input
+ *  re-renders every component bound to it. */
+/** Plain text of a list item, for the local filter. */
+function listItemText(item: GenuiList['items'][number]): string {
+  if (typeof item === 'string') return item
+  if (isListItemNode(item)) return ''
+  return `${item.title} ${item.desc ?? ''}`
+}
+
+function boundField(answers: AnswersState | undefined, id: string | undefined): string | undefined {
+  if (id === undefined) return undefined
+  const value = answers?.fields[id]
+  return value === undefined || value === '' ? undefined : value
+}
+
 export function renderNode(
   node: GenuiNode,
   key: number,
@@ -284,7 +300,11 @@ export function renderNode(
     }
     case 'divider': return <hr key={key} className={css.divider} />
     case 'list': {
-      const items = node.items.slice(0, GENUI_LIMITS.maxListItems)
+      const bound = boundField(answers, node.filter)?.toLowerCase()
+      const all = node.items.slice(0, GENUI_LIMITS.maxListItems)
+      const items = bound === undefined
+        ? all
+        : all.filter(item => listItemText(item).toLowerCase().includes(bound))
       return (
         <div key={key} className={css.list}>
           {items.map((item, i) => (
@@ -294,6 +314,7 @@ export function renderNode(
                 : <><span className={css.liTitle}>{typeof item === 'string' ? item : item.title}</span>{typeof item !== 'string' && item.desc !== undefined && <span className={css.liDesc}>{item.desc}</span>}</>}
             </div>
           ))}
+          {bound !== undefined && <span className={css.filterHint}>匹配 {items.length} / {all.length} 项</span>}
         </div>
       )
     }
@@ -302,10 +323,15 @@ export function renderNode(
         <TableNode
           key={key}
           node={node}
+          // Bound controls are resolved here: the table (and the chart below)
+          // receive plain strings, so they stay presentational and the live
+          // filtering never needs a model round trip.
+          filterValue={boundField(answers, node.filter)}
+          sortValue={boundField(answers, node.sortField)}
           renderDetail={items => items.map((child, i) => renderNode(child, i, onAction, depth + 1, answers))}
         />
       )
-    case 'chart': return <ChartNode key={key} chart={node} />
+    case 'chart': return <ChartNode key={key} chart={node} filterValue={boundField(answers, node.filter)} />
     case 'tabs': return <TabsNode key={key} tabs={node} onAction={onAction} depth={depth + 1} answers={answers} />
     case 'avatar': {
       return (

--- a/src/client/gallery.ts
+++ b/src/client/gallery.ts
@@ -77,6 +77,12 @@ export const gallerySpec: GenuiSpec = {
     { type: 'chart', horizontal: true, data: [
       { label: '自然搜索', value: 82 }, { label: '直接访问', value: 64 }, { label: '社交媒体', value: 41 },
     ] },
+    { type: 'input', label: '筛选服务 / 状态', placeholder: '输入关键字即时过滤下表', id: 'gallery-filter' },
+    { type: 'table', columns: ['服务', 'P95', '状态'], types: ['text', 'num', 'badge'], filter: 'gallery-filter', rows: [
+      ['API 网关', '128', '正常'],
+      ['搜索', '190', '关注'],
+      ['推荐', '250', '偏高'],
+    ] },
     { type: 'table', columns: ['服务', 'P95', '状态'], types: ['text', 'num', 'badge'], details: [
       [{ type: 'keyvalue', pairs: [{ key: '负责人', value: '平台组' }, { key: 'SLO', value: 'P95 < 150ms' }] },
        { type: 'text', size: 'body', content: '展开行可以放任意组件：指标、图表、列表、表单都可以。' }],

--- a/src/client/genui-runtime/schema.ts
+++ b/src/client/genui-runtime/schema.ts
@@ -249,6 +249,7 @@ export const COMPONENT_SCHEMAS: Readonly<Record<string, ComponentSchema>> = {
     series: 'array',
     horizontal: 'boolean',
     stacked: 'boolean',
+    filter: 'string',
   }, {}, {
     oneOfRequired: [['data', 'series']],
     // `line` may carry its points in `series` (multi-series line); only the
@@ -281,7 +282,7 @@ export const COMPONENT_SCHEMAS: Readonly<Record<string, ComponentSchema>> = {
   json: schema(['value'], { ...nodeFields, value: 'unknown' }),
   keyvalue: schema(['pairs'], { ...nodeFields, pairs: 'array' }, {}, { nested: { pairs: keyValueRecordSchema } }),
   link: schema(['label'], { ...nodeFields, label: 'string', href: 'string' }),
-  list: schema(['items'], { ...nodeFields, items: 'array' }),
+  list: schema(['items'], { ...nodeFields, items: 'array', filter: 'string' }),
   mermaid: schema(['code'], { ...nodeFields, code: 'string' }),
   plot: schema(['series'], { ...nodeFields, series: 'array', xMin: 'number', xMax: 'number', yMin: 'number', yMax: 'number', title: 'string' }, {}, { nested: { series: plotSeriesSchema } }),
   progress: schema(['value'], { ...nodeFields, value: 'number', label: 'string', valueLabel: 'string', variant: 'string', target: 'number' }, {}, { enums: { variant: PROGRESS_VARIANTS } }),
@@ -296,7 +297,7 @@ export const COMPONENT_SCHEMAS: Readonly<Record<string, ComponentSchema>> = {
   steps: schema(['steps'], { ...nodeFields, steps: 'array', current: 'number' }, { items: 'steps' }, { nested: { steps: stepsRecordSchema } }),
   submit: schema(['label'], { ...nodeFields, label: 'string', action: 'string', resetAction: 'string', groups: 'array' }),
   switch: schema(['label'], { ...nodeFields, label: 'string', checked: 'boolean', action: 'string' }),
-  table: schema(['columns', 'rows'], { ...nodeFields, columns: 'array', rows: 'array', types: 'array', total: 'boolean', details: 'array' }, { headers: 'columns', data: 'rows' }),
+  table: schema(['columns', 'rows'], { ...nodeFields, columns: 'array', rows: 'array', types: 'array', total: 'boolean', details: 'array', filter: 'string', filterColumn: 'number', sortField: 'string' }, { headers: 'columns', data: 'rows' }),
   tabs: schema(['tabs'], { ...nodeFields, tabs: 'array' }, {}, { nested: { tabs: tabHolderSchema } }),
   text: schema(['content'], { ...nodeFields, content: 'string', size: 'string', center: 'boolean' }, { text: 'content' }, { enums: { size: TEXT_SIZES } }),
   textarea: schema([], { ...nodeFields, label: 'string', placeholder: 'string', rows: 'number', value: 'string', action: 'string', id: 'string' }),

--- a/src/client/guard.ts
+++ b/src/client/guard.ts
@@ -365,7 +365,7 @@ function repairNode(value: unknown, ctx: RepairCtx, depth: number): GenuiNode | 
     case 'list': {
       const items = repairListItems(v.items, GENUI_LIMITS.maxListItems, ctx, depth + 1)
       if (items === undefined) return null
-      return { type: 'list', items }
+      return { type: 'list', items, ...opt('filter', str(v.filter, 64)) }
     }
     case 'table': {
       let rawCols = v.columns as unknown
@@ -411,6 +411,9 @@ function repairNode(value: unknown, ctx: RepairCtx, depth: number): GenuiNode | 
         type: 'table', columns, rows,
         ...opt('types', types),
         ...opt('total', v.total === true ? true : undefined),
+        ...opt('filter', str(v.filter, 64)),
+        ...opt('filterColumn', int(v.filterColumn, 0, GENUI_LIMITS.maxTableCols - 1)),
+        ...opt('sortField', str(v.sortField, 64)),
         ...opt('details', details !== undefined && details.some(d => d !== null) ? details : undefined),
       }
     }
@@ -427,6 +430,7 @@ function repairNode(value: unknown, ctx: RepairCtx, depth: number): GenuiNode | 
         ...opt('series', series),
         ...opt('horizontal', v.horizontal === true ? true : undefined),
         ...opt('stacked', v.stacked === true ? true : undefined),
+        ...opt('filter', str(v.filter, 64)),
       }
     }
     case 'tabs': {

--- a/src/client/spec.ts
+++ b/src/client/spec.ts
@@ -261,6 +261,8 @@ export interface GenuiCard {
 
 export interface GenuiList {
   type: 'list'
+  /** Field id of an input/select: its value filters the items locally. */
+  filter?: string
   items: Array<string | { title: string; desc?: string } | GenuiNode>
 }
 
@@ -275,6 +277,13 @@ export interface GenuiTable {
   /** Optional master-detail payload, positionally aligned with `rows`:
    *  `details[i]` is what row i expands into (omit / empty = not expandable). */
   details?: Array<GenuiNode[] | null>
+  /** Field id of an input/select: its live value filters the rows locally
+   *  (substring match), so the table is searchable without a model round trip. */
+  filter?: string
+  /** Restrict `filter` to one column index (default: every column). */
+  filterColumn?: number
+  /** Field id of a select whose value is a column header: sorts by it locally. */
+  sortField?: string
 }
 
 /** How a table column's cells render.
@@ -301,6 +310,8 @@ export interface GenuiChart {
   horizontal?: boolean
   /** Bars + series: stack the series instead of grouping them. */
   stacked?: boolean
+  /** Field id of an input/select: its value filters the categories locally. */
+  filter?: string
 }
 
 export interface GenuiTab {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -103,9 +103,10 @@ The spec is a white-listed component tree rendered inline where the fence sits. 
 **默认就该出 UI**：出现下列情况至少出一个围栏：
 - ≥3 条并列要点 → \`list\`；数字对比 → \`table\`；指标/进度/状态 → \`stat\`/\`progress\`/\`badge\`
 - 步骤/时间线 → \`steps\`/\`timeline\`/\`mermaid\`；架构/流程 → \`diagram\` 或 \`mermaid\`；风险/结论 → \`callout\`；代码/改动 → \`code\`/\`diff\`/\`json\`
-- 趋势/占比 → \`chart\`（≤8 点）或 \`echart\`（多序列/要交互时）；正文以组件承载为主：能结构化的段落一律换成组件，文字只做连接与结论，同一份信息不要既写文字又重复出组件。
+- 趋势/占比 → \`chart\`（≤8 点）或 \`echart\`（多序列/要交互时）；数据多时给 \`table\`/\`chart\`/\`list\` 配一个 \`input\`(id) + \`filter\` 绑定，读者能就地筛选，不用再问一遍
+- 正文以组件承载为主：能结构化的段落一律换成组件，文字只做连接与结论，同一份信息不要既写文字又重复出组件。
 
-**字段速查**（完整见 genui skill）：\`stat\` \`{"label":"…","value":"…","delta":"+1.2%"}\` · \`table\` \`{"columns":["…"],"rows":[["…"]],"types":["bar|spark|ring|badge|delta|num|index|group"]?,"total":true?,"details":[[…]]?}\` · \`callout\` \`{"tone":"info|success|warning|error","title":"…","content":"…"}\` · \`progress\` \`{"value":72,"variant":"ring"?,"target":80?}\`
+**字段速查**（完整见 genui skill）：\`stat\` \`{"label":"…","value":"…","delta":"+1.2%"}\` · \`table\` \`{"columns":["…"],"rows":[["…"]],"types":["…"]?,"total":true?,"details":[[…]]?,"filter":"输入框id"?,"sortField":"下拉id"?}\` · \`callout\` \`{"tone":"info|success|warning|error","title":"…","content":"…"}\` · \`progress\` \`{"value":72,"variant":"ring"?,"target":80?}\`
 
 Rules:
 - JSON 严格: 坏围栏降级为代码块；≥3 节点或含 table 的围栏发出前调用 validate_dsh_ui，❌ 修好再发（若附「已自动修复」JSON 照抄即可）。

--- a/tests/genui-v29.spec.tsx
+++ b/tests/genui-v29.spec.tsx
@@ -29,6 +29,72 @@ function renderBlock(spec: unknown, actions: Array<[string, Record<string, unkno
   )
 }
 
+describe('v12: 本地数据绑定（就地筛选）', () => {
+  it('filters table rows from a bound input, live', () => {
+    const { container } = renderBlock({
+      items: [
+        { type: 'input', id: 'q', label: '搜索' },
+        { type: 'table', columns: ['服务', 'P95'], filter: 'q', rows: [['API 网关', '128'], ['搜索', '190'], ['推荐', '250']] },
+      ],
+    })
+    const rows = () => container.querySelectorAll('tbody tr')
+    expect(rows()).toHaveLength(3)
+    fireEvent.change(container.querySelector('input')!, { target: { value: '搜索' } })
+    expect(rows()).toHaveLength(1)
+    expect(container.querySelector('tbody')?.textContent).toContain('190')
+    expect(container.textContent).toContain('筛选后 1 / 3 行')
+    fireEvent.change(container.querySelector('input')!, { target: { value: '' } })
+    expect(rows()).toHaveLength(3)
+  })
+
+  it('restricts the filter to one column when filterColumn is set', () => {
+    const { container } = renderBlock({
+      items: [
+        { type: 'input', id: 'q' },
+        { type: 'table', columns: ['服务', '备注'], filter: 'q', filterColumn: 0, rows: [['API', '网关'], ['搜索', 'API']] },
+      ],
+    })
+    fireEvent.change(container.querySelector('input')!, { target: { value: 'api' } })
+    const body = container.querySelector('tbody')?.textContent ?? ''
+    expect(body).toContain('API')
+    expect(body).not.toContain('搜索')
+  })
+
+  it('sorts by a bound select value', () => {
+    const { container } = renderBlock({
+      items: [
+        { type: 'select', id: 'sort', options: ['P95'] },
+        { type: 'table', columns: ['服务', 'P95'], sortField: 'sort', rows: [['A', '250'], ['B', '128']] },
+      ],
+    })
+    fireEvent.change(container.querySelector('select')!, { target: { value: 'P95' } })
+    const first = container.querySelector('tbody tr')?.textContent ?? ''
+    expect(first).toContain('B')
+  })
+
+  it('filters chart categories and list items', () => {
+    const chart = renderBlock({
+      items: [
+        { type: 'input', id: 'q' },
+        { type: 'chart', filter: 'q', data: [{ label: '搜索', value: 82 }, { label: '社交', value: 41 }] },
+      ],
+    })
+    fireEvent.change(chart.container.querySelector('input')!, { target: { value: '搜索' } })
+    expect(chart.container.querySelectorAll('[class*="barCol"]')).toHaveLength(1)
+    chart.unmount()
+
+    const list = renderBlock({
+      items: [
+        { type: 'input', id: 'q' },
+        { type: 'list', filter: 'q', items: ['苹果', '香蕉', '苹果派'] },
+      ],
+    })
+    fireEvent.change(list.container.querySelector('input')!, { target: { value: '苹果' } })
+    expect(list.container.querySelectorAll('[class*="li"]').length).toBeGreaterThanOrEqual(2)
+    expect(list.container.textContent).toContain('匹配 2 / 3 项')
+  })
+})
+
 describe('v11: table master-detail rows', () => {
   it('expands a row into its detail panel and folds it back', () => {
     const { container } = renderBlock({


### PR DESCRIPTION
以前换筛选条件只能让模型把整份数据重新生成一遍。现在模型发一次数据，读者自己就能筛。\n\n- `table.filter` / `chart.filter` / `list.filter` 绑定 input/select 的 `id`，实时子串过滤（大小写无关）；`table.filterColumn` 限定列，`table.sortField` 用下拉值排序。\n- 绑定值在 render-node 解析成字符串再传下去，筛选是纯客户端行为：不发请求、不触发 action、不改持久化格式。\n- 过滤发生在分组/合计之前：合计只算可见行、分组不出现空组；底部显示「筛选后 N / M 行」。\n- 空过滤值 = 不过滤；不带绑定时行为与之前一致。\n\n文档：SKILL.md 增加「数据多 → input + filter」映射与字段说明，常驻提示同步。\n\n验证：tsc · 524 测试 · 构建 · 视觉 E2E（真实浏览器 22 → 20 → 22 行，清空恢复）。