### PR TITLE
feat(layout): hero 封面块 + span 跨列（bento）+ 数字入场动效

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -22,6 +22,8 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 - text: `{"type":"text","size":"h1|h2|h3|body|muted|caption","content":"...","center":true?}`
 - row / col: `{"type":"row"|"col","items":[...],"wrap":true?,"spacer":true?,"gap":n?}`
 - grid: `{"type":"grid","cols":n,"items":[...]}`
+- hero: `{"type":"hero","title":"...","subtitle":"...","value":"99.96%","label":"可用率","delta":"+0.02%","spark":[...],"tone":"accent|success|warning|danger"}` — **封面块**：eyebrow + 超大数字（52px，带入场计数）+ 标题 + 副标题 + tone 渐变底色。**一条回答最多用一个**，放在最前面当视觉锚点
+- span: 任意节点都可加 `"span":2`（grid 子节点占几列）——bento 排版的唯一原语：一张 `span:2` 宽卡配一张窄卡，比一列方块堆下去好看得多
 - card: `{"type":"card","title":"...","items":[...]}`；`"tone":"info|success|warning|danger"` 给卡片底色（用于结论卡/风险卡）
 - divider: `{"type":"divider"}`; spacer: `{"type":"spacer"}`
 
@@ -93,6 +95,8 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 | 重点强调 / 警告 / 注意事项 | `callout`（info/success/warning/error）、`badge`、`stat` |
 | 数据对比 / 趋势 / 占比 | `chart`（bars/line/donut）、`echart`（ECharts 全功能）、`table` |
 | 关键指标数字 / 进度状态 | `stat`、`progress`、`badge` |
+| 回答的视觉锚点（第一个组件） | `hero`（封面块，一条回答最多一个） |
+| 想排版不呆板 | `grid` + 子节点 `span`（bento：宽窄混排） |
 | 数据多、需要读者自己找 | `input`（id）+ `table`/`chart`/`list` 的 `filter` 绑定 |
 | 流程 / 步骤 / 阶段 / 时间线 | `steps`、`timeline`、`mermaid`（flowchart/sequence/gantt） |
 | 架构 / 系统拓扑 / 数据流 / 品牌图 | `diagram`（编辑级，27 种类型；自动布局需求才用 `mermaid`） |

--- a/src/client/GenuiBlock.module.css
+++ b/src/client/GenuiBlock.module.css
@@ -91,6 +91,10 @@
 .row { display: flex; align-items: center; gap: var(--dsl-g-gap-md); }
 .row.wrap { flex-wrap: wrap; }
 .grid { display: grid; gap: var(--dsl-g-gap-md); }
+/* Bento child: occupies N grid columns (the wrapper exists only so the child
+   keeps its own layout). */
+.gridSpan { display: flex; flex-direction: column; min-width: 0; }
+.gridSpan > * { flex: 1; }
 /* Narrow conversation column (phone / split pane): a fixed 3-4 column grid
    would squeeze every cell, so the grid collapses to one column. The inline
    gridTemplateColumns from the spec needs !important to be overridden. */
@@ -267,6 +271,67 @@
 .mediaPlayer { display: block; width: 100%; min-width: 0; }
 .videoPlayer { max-height: min(70vh, 720px); background: #000; object-fit: contain; }
 .mediaError { font-size: var(--dsl-g-font-title); color: var(--dsw-alias-state-error-primary, #f25a5a); }
+
+/* ---------- hero (cover band) ----------
+   The answer's focal point: an eyebrow, an oversized metric, a title and a
+   subtitle on a soft tinted surface. Tone changes the wash, never the layout. */
+
+.hero {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 22px 24px 24px;
+  border-radius: 14px;
+  border: 1px solid var(--dsl-g-border);
+  background:
+    radial-gradient(120% 140% at 100% 0%, color-mix(in srgb, var(--dsl-g-accent) 22%, transparent) 0%, transparent 58%),
+    linear-gradient(180deg, color-mix(in srgb, var(--dsl-g-accent) 7%, transparent), transparent 70%),
+    var(--dsw-alias-bg-layer-1, transparent);
+  overflow: hidden;
+}
+.heroSuccess {
+  background:
+    radial-gradient(120% 140% at 100% 0%, color-mix(in srgb, var(--dsw-alias-state-success-primary, #3ecf8e) 20%, transparent) 0%, transparent 58%),
+    linear-gradient(180deg, color-mix(in srgb, var(--dsw-alias-state-success-primary, #3ecf8e) 6%, transparent), transparent 70%),
+    var(--dsw-alias-bg-layer-1, transparent);
+}
+.heroWarning {
+  background:
+    radial-gradient(120% 140% at 100% 0%, color-mix(in srgb, var(--dsw-alias-state-warn-primary, #f5b83d) 20%, transparent) 0%, transparent 58%),
+    linear-gradient(180deg, color-mix(in srgb, var(--dsw-alias-state-warn-primary, #f5b83d) 6%, transparent), transparent 70%),
+    var(--dsw-alias-bg-layer-1, transparent);
+}
+.heroDanger {
+  background:
+    radial-gradient(120% 140% at 100% 0%, color-mix(in srgb, var(--dsw-alias-state-error-primary, #ff6b6b) 18%, transparent) 0%, transparent 58%),
+    linear-gradient(180deg, color-mix(in srgb, var(--dsw-alias-state-error-primary, #ff6b6b) 6%, transparent), transparent 70%),
+    var(--dsw-alias-bg-layer-1, transparent);
+}
+.heroLabel {
+  font-size: var(--dsl-g-font-meta);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--dsw-alias-label-secondary);
+}
+.heroTop { display: flex; align-items: baseline; gap: var(--dsl-g-gap-md); flex-wrap: wrap; }
+.heroValue {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-family: var(--dsl-g-font-mono);
+  font-size: 52px;
+  font-weight: 750;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  color: var(--dsw-alias-label-primary);
+  font-variant-numeric: tabular-nums;
+}
+.heroUnit { font-size: 0.44em; font-weight: 650; letter-spacing: 0; color: var(--dsw-alias-label-secondary); }
+.heroSpark { margin-left: auto; width: 168px; align-self: center; }
+.heroTitle { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; color: var(--dsw-alias-label-primary); line-height: 1.3; }
+.heroSubtitle { font-size: var(--dsl-g-font-title); color: var(--dsw-alias-label-secondary); line-height: 1.6; text-wrap: pretty; }
 
 /* ---------- badges / stat / progress ---------- */
 

--- a/src/client/blocks/render-node.tsx
+++ b/src/client/blocks/render-node.tsx
@@ -4,7 +4,7 @@
  * the sibling block modules. Depth-guarded against pathological specs.
  * @module @changfenhuang/dsh-genui/client/blocks/render-node
  */
-import { type ReactNode, type ComponentType } from 'react'
+import { type ComponentType, type ReactNode, useEffect, useState } from 'react'
 import * as primitives from '@deepseek-ai/dsh-client-ui-primitives'
 import css from '../GenuiBlock.module.css'
 import { GENUI_LIMITS } from '../genui-runtime/index.ts'
@@ -54,10 +54,24 @@ function isListItemNode(item: GenuiList['items'][number]): item is GenuiNode {
  * `6.8 GB` → `6.8` + `GB`). Values that do not start with a number are left
  * whole.
  */
-function splitStatValue(value: string): { num: string; unit: string } {
+function splitStatValue(value: string): {
+  num: string
+  unit: string
+  /** Parsed number when the numeric core is a plain decimal (for count-up). */
+  numeric: number | undefined
+  /** Decimal places to keep while animating. */
+  decimals: number
+} {
   const match = /^([+\-−]?[\d.,]+(?:[eE][+\-]?\d+)?)\s*(.*)$/.exec(value.trim())
-  if (match === null || match[1] === undefined) return { num: value, unit: '' }
-  return { num: match[1], unit: match[2] ?? '' }
+  if (match === null || match[1] === undefined) return { num: value, unit: '', numeric: undefined, decimals: 0 }
+  const raw = match[1]
+  const plain = raw.replace(/[,，]/g, '')
+  const parsed = Number(plain)
+  // Commas are thousands separators in a number, but a grouped metric like
+  // "1,2" is not worth animating — keep it static.
+  const numeric = Number.isFinite(parsed) && !/[eE]/.test(plain) ? parsed : undefined
+  const decimals = plain.includes('.') ? (plain.split('.')[1] ?? '').length : 0
+  return { num: raw, unit: match[2] ?? '', numeric, decimals: Math.min(decimals, 4) }
 }
 
 /**
@@ -108,6 +122,55 @@ function Sparkline({ values }: { values: number[] }) {
 /** Live value of a bound control (`node.filter` / `node.sortField`): the field id
  *  resolves against the block's shared field registry, so typing in an input
  *  re-renders every component bound to it. */
+/**
+ * Animate a metric from 0 to its target once on mount. Only used for values
+ * that are pure numbers with an optional unit — counting up "v0.9.9" would be
+ * nonsense, and prefers-reduced-motion turns it off entirely.
+ */
+function useCountUp(target: number, decimals: number, enabled: boolean): string {
+  const [value, setValue] = useState(enabled ? 0 : target)
+  useEffect(() => {
+    if (!enabled) { setValue(target); return }
+    const reduce = typeof window !== 'undefined'
+      && typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduce) { setValue(target); return }
+    let raf = 0
+    const start = performance.now()
+    const duration = 720
+    const tick = (now: number): void => {
+      const t = Math.min(1, (now - start) / duration)
+      const eased = 1 - Math.pow(1 - t, 3)
+      setValue(target * eased)
+      if (t < 1) raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [target, enabled])
+  return value.toFixed(decimals)
+}
+
+/** Animated metric text: splits the value into number + unit and counts the
+ *  number up once. A component (not a helper) so the hook has a stable owner —
+ *  renderNode's switch must never call hooks conditionally. */
+function AnimatedValue({ value, unitClass, animate = false }: {
+  value: string
+  unitClass?: string | undefined
+  /** Only hero-scale numbers count up: a grid of eight stats all ticking at
+   *  once reads as a gimmick, not as polish. */
+  animate?: boolean | undefined
+}) {
+  const parts = splitStatValue(value)
+  const target = parts.numeric
+  const animated = useCountUp(target ?? 0, parts.decimals, animate && target !== undefined)
+  return (
+    <>
+      {target === undefined ? parts.num : animated}
+      {parts.unit !== '' && <span className={unitClass ?? css.statUnit}>{parts.unit}</span>}
+    </>
+  )
+}
+
 /** Plain text of a list item, for the local filter. */
 function listItemText(item: GenuiList['items'][number]): string {
   if (typeof item === 'string') return item
@@ -161,7 +224,15 @@ export function renderNode(
     case 'grid': {
       return (
         <div key={key} className={css.grid} style={{ gridTemplateColumns: `repeat(${Math.max(1, node.cols)}, minmax(0, 1fr))` }}>
-          {node.items.map((c, i) => renderNode(c, i, onAction, depth + 1, answers))}
+          {/* `span` is the bento primitive: a child can occupy several columns,
+              so one wide hero card can sit next to two narrow ones. */}
+          {node.items.map((c, i) => {
+            const child = renderNode(c, i, onAction, depth + 1, answers)
+            const span = typeof c === 'object' && c !== null && typeof (c as { span?: unknown }).span === 'number'
+              ? Math.max(1, Math.min(12, (c as { span: number }).span))
+              : 1
+            return span > 1 ? <div key={i} className={css.gridSpan} style={{ gridColumn: `span ${span}` }}>{child}</div> : child
+          })}
         </div>
       )
     }
@@ -218,15 +289,34 @@ export function renderNode(
         </span>
       )
     }
+    case 'hero': {
+      const tone = node.tone ?? 'accent'
+      const heroTone = css[`hero${tone[0]!.toUpperCase()}${tone.slice(1)}`] ?? ''
+      const heroDown = node.delta !== undefined && node.delta.startsWith('-')
+      return (
+        <div key={key} className={`${css.hero} ${heroTone}`}>
+          {node.label !== undefined && <span className={css.heroLabel}>{node.label}</span>}
+          <div className={css.heroTop}>
+            {node.value !== undefined && (
+              <span className={css.heroValue}><AnimatedValue value={node.value} unitClass={css.heroUnit} animate /></span>
+            )}
+            {node.delta !== undefined && (
+              <span className={`${css.statDelta} ${heroDown ? css.down : css.up}`}>{node.delta}</span>
+            )}
+            {node.spark !== undefined && <span className={css.heroSpark}><Sparkline values={node.spark} /></span>}
+          </div>
+          <span className={css.heroTitle}>{node.title}</span>
+          {node.subtitle !== undefined && <span className={css.heroSubtitle}>{node.subtitle}</span>}
+        </div>
+      )
+    }
     case 'stat': {
       const down = node.delta !== undefined && node.delta.startsWith('-')
-      const parts = splitStatValue(node.value)
       return (
         <div key={key} className={`${css.stat}${node.size === 'hero' ? ` ${css.statHero}` : ''}`}>
           <span className={css.statLabel}>{node.label}</span>
           <span className={css.statValue}>
-            {parts.num}
-            {parts.unit !== '' && <span className={css.statUnit}>{parts.unit}</span>}
+            <AnimatedValue value={node.value} animate={node.size === 'hero'} />
           </span>
           {node.delta !== undefined && <span className={`${css.statDelta} ${down ? css.down : css.up}`}>{node.delta}</span>}
           {node.spark !== undefined && <Sparkline values={node.spark} />}

--- a/src/client/gallery.ts
+++ b/src/client/gallery.ts
@@ -9,6 +9,11 @@ export const gallerySpec: GenuiSpec = {
   title: 'GenUI · 组件画廊',
   gap: 14,
   items: [
+    { type: 'hero', label: '可用率 · 近 30 天', value: '99.96%', delta: '+0.02%', tone: 'accent', spark: [99.8, 99.85, 99.9, 99.88, 99.94, 99.96], title: 'hero 封面块', subtitle: '一条回答最多一个：eyebrow + 超大数字 + 标题 + 副标题，带 tone 渐变底色。' },
+    { type: 'grid', cols: 3, items: [
+      { type: 'card', span: 2, title: 'span:2 的卡片', items: [{ type: 'text', size: 'body', content: 'grid 子节点加 span 就能跨列——bento 排版靠它：一张宽卡 + 一张窄卡。' }] },
+      { type: 'card', title: 'span:1', items: [{ type: 'text', size: 'body', content: '默认占一列。' }] },
+    ] },
     { type: 'text', size: 'h1', content: '排版层级' },
     { type: 'text', size: 'h2', content: '二级标题' },
     { type: 'text', size: 'h3', content: '三级标题' },

--- a/src/client/genui-runtime/schema.ts
+++ b/src/client/genui-runtime/schema.ts
@@ -82,6 +82,8 @@ export const STAT_SIZES = ['hero'] as const
 export const PROGRESS_VARIANTS = ['bar', 'ring'] as const
 /** Semantic card surfaces. */
 export const CARD_TONES = ['info', 'success', 'warning', 'danger'] as const
+/** Hero cover tones. */
+export const HERO_TONES = ['accent', 'success', 'warning', 'danger'] as const
 /** Table cell renderers (`table.types`, one entry per column). */
 export const TABLE_CELL_TYPES = ['text', 'num', 'delta', 'bar', 'badge', 'spark', 'ring', 'index', 'group'] as const
 
@@ -127,7 +129,7 @@ const recordSchema = (
   enums: Readonly<Record<string, readonly string[]>> = {},
 ): ComponentRecordSchema => ({ required, fields, enums, nested })
 
-const nodeFields = { type: 'string' } as const
+const nodeFields = { type: 'string', span: 'number' } as const
 
 const chartDatumSchema = recordSchema(['label', 'value'], {
   label: 'string',
@@ -293,6 +295,16 @@ export const COMPONENT_SCHEMAS: Readonly<Record<string, ComponentSchema>> = {
   select: schema(['options'], { ...nodeFields, label: 'string', options: 'array', action: 'string', selected: 'number', id: 'string' }),
   slider: schema([], { ...nodeFields, label: 'string', min: 'number', max: 'number', step: 'number', value: 'number', action: 'string', id: 'string' }),
   spacer: schema([], nodeFields),
+  hero: schema(['title'], {
+    ...nodeFields,
+    title: 'string',
+    subtitle: 'string',
+    value: 'string',
+    label: 'string',
+    delta: 'string',
+    spark: 'array',
+    tone: 'string',
+  }, {}, { enums: { tone: HERO_TONES } }),
   stat: schema(['label', 'value'], { ...nodeFields, label: 'string', value: 'string', delta: 'string', spark: 'array', size: 'string' }, {}, { enums: { size: STAT_SIZES } }),
   steps: schema(['steps'], { ...nodeFields, steps: 'array', current: 'number' }, { items: 'steps' }, { nested: { steps: stepsRecordSchema } }),
   submit: schema(['label'], { ...nodeFields, label: 'string', action: 'string', resetAction: 'string', groups: 'array' }),

--- a/src/client/guard.ts
+++ b/src/client/guard.ts
@@ -21,7 +21,7 @@
 import type { GenuiFileTreeNode, GenuiList, GenuiNode, GenuiPlot, GenuiPlotSeries, GenuiScene3D, GenuiSpec, GenuiDiagram, GenuiDiagramTheme, GenuiDiagramKind } from './spec.ts'
 import { wrapSingleComponentRoot } from './spec.ts'
 import {
-  BADGE_TONES, BUTTON_TONES, CALLOUT_TONES, CARD_TONES, CHART_KINDS, COMPONENT_SCHEMAS,
+  BADGE_TONES, BUTTON_TONES, CALLOUT_TONES, CARD_TONES, CHART_KINDS, COMPONENT_SCHEMAS, HERO_TONES,
   DIAGRAM_EDGE_KINDS, DIAGRAM_KINDS, DIAGRAM_NODE_TYPES, DIAGRAM_ROUTES, DIAGRAM_VARIANTS,
   ECHART_PRESETS, FILE_TYPES, GENUI_NATIVE_TYPES, GENUI_SPEC_SCHEMA, INPUT_TYPES,
   MEDIA_ASPECT_RATIOS, MESH_SHAPES, PLOT_KINDS, PROGRESS_VARIANTS, TABLE_CELL_TYPES, TEXT_SIZES,
@@ -221,7 +221,17 @@ function sparkValues(v: unknown): number[] | undefined {
   return out.length >= 2 ? out : undefined
 }
 
+/** Layout hints are component-agnostic: `span` survives repair on ANY node
+ *  (the renderer applies it inside a grid). Kept out of the per-case switches
+ *  so a new component type cannot forget it. */
 function repairNode(value: unknown, ctx: RepairCtx, depth: number): GenuiNode | null {
+  const node = repairNodeFields(value, ctx, depth)
+  if (node === null) return null
+  const span = int(obj(value)?.span, 2, 12)
+  return span === undefined ? node : ({ ...node, span } as GenuiNode)
+}
+
+function repairNodeFields(value: unknown, ctx: RepairCtx, depth: number): GenuiNode | null {
   if (depth > GENUI_LIMITS.maxDepth) return null
   const v = obj(value)
   if (v === undefined) return null
@@ -332,6 +342,19 @@ function repairNode(value: unknown, ctx: RepairCtx, depth: number): GenuiNode | 
       const label = str(v.label, GENUI_LIMITS.maxString) ?? str(v.text, GENUI_LIMITS.maxString) ?? str(v.value, GENUI_LIMITS.maxString)
       if (label === undefined) return null
       return { type: 'badge', label, ...opt('tone', enu(v.tone, BADGE_TONES)), ...opt('icon', str(v.icon, 64)) }
+    }
+    case 'hero': {
+      const title = str(v.title, GENUI_LIMITS.maxString)
+      if (title === undefined) return null
+      return {
+        type: 'hero', title,
+        ...opt('subtitle', str(v.subtitle, GENUI_LIMITS.maxString)),
+        ...opt('value', str(v.value, 128)),
+        ...opt('label', str(v.label, GENUI_LIMITS.maxString)),
+        ...opt('delta', str(v.delta, 64)),
+        ...opt('spark', sparkValues(v.spark)),
+        ...opt('tone', enu(v.tone, HERO_TONES)),
+      }
     }
     case 'stat': {
       const label = str(v.label, GENUI_LIMITS.maxString)
@@ -1653,6 +1676,10 @@ function validateNode(value: unknown, depth: number, at: string, errors: string[
       isStr('label')
       isStr('text')
       isStr('value')
+      break
+    case 'hero':
+      if (typeof v.title !== 'string') errors.push(`${at}: type 'hero' requires title (string)`)
+      isStr('subtitle')
       break
     case 'stat':
       if (typeof v.label !== 'string') errors.push(`${at}: type 'stat' requires label (string)`)

--- a/src/client/spec.ts
+++ b/src/client/spec.ts
@@ -10,7 +10,13 @@
  */
 
 /** One node in the component tree. */
-export type GenuiNode =
+/** Layout hints accepted by every node: `span` is how many columns the node
+ *  occupies as a direct child of a `grid` (bento layouts). */
+export interface GenuiLayoutHints {
+  span?: number
+}
+
+export type GenuiNode = (
   | GenuiText
   | GenuiRow
   | GenuiCol
@@ -26,6 +32,7 @@ export type GenuiNode =
   | GenuiVideo
   | GenuiBadge
   | GenuiStat
+  | GenuiHero
   | GenuiProgress
   | GenuiDivider
   | GenuiList
@@ -55,6 +62,7 @@ export type GenuiNode =
   | GenuiBreadcrumb
   | GenuiQuiz
   | GenuiDiagram
+) & GenuiLayoutHints
 
   | GenuiEChart
 
@@ -192,6 +200,21 @@ export interface GenuiBadge {
   label: string
   tone?: 'success' | 'warn' | 'danger' | 'accent'
   icon?: string
+}
+
+/** Cover band: the answer's focal point. One per fence — an eyebrow label, an
+ *  oversized metric, a title and a subtitle on a soft tinted surface. */
+export interface GenuiHero {
+  type: 'hero'
+  title: string
+  subtitle?: string
+  /** Oversized metric, e.g. "99.96%" / "3.2x". */
+  value?: string
+  /** Eyebrow label above the metric. */
+  label?: string
+  delta?: string
+  spark?: number[]
+  tone?: 'accent' | 'success' | 'warning' | 'danger'
 }
 
 export interface GenuiStat {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -94,7 +94,7 @@ export const GENUI_SECTION_TEXT = `You can render interactive UI components INSI
 
 The spec is a white-listed component tree rendered inline where the fence sits. Only these \`type\` values; the \`genui\` skill, when available, carries the full content→component mapping and per-component field details:
 
-- 布局: text · row · col · grid · card · divider · spacer
+- 布局: text · row · col · grid · card · divider · spacer · hero（封面块：超大数字 + 标题 + tone 渐变底色，一条回答最多一个）
 - 展示: badge · stat · progress · list · table · keyvalue · avatar · audio · video · timeline · file-tree · breadcrumb · callout · steps · diff · json · code · copy
 - 图表: chart {"kind":"bars|line|donut","data":[{"label":"...","value":n}],"series":[{"label":"...","data":[...]}]?,"horizontal":true?,"stacked":true?}（series：bars 分组/堆叠 / line 多序列；horizontal 横向柱） · echart (preset|option) · plot (函数图)
 - 交互: button · input · textarea · select · checkbox · switch · slider · radio · submit · quiz · link · tabs · accordion
@@ -103,7 +103,7 @@ The spec is a white-listed component tree rendered inline where the fence sits. 
 **默认就该出 UI**：出现下列情况至少出一个围栏：
 - ≥3 条并列要点 → \`list\`；数字对比 → \`table\`；指标/进度/状态 → \`stat\`/\`progress\`/\`badge\`
 - 步骤/时间线 → \`steps\`/\`timeline\`/\`mermaid\`；架构/流程 → \`diagram\` 或 \`mermaid\`；风险/结论 → \`callout\`；代码/改动 → \`code\`/\`diff\`/\`json\`
-- 趋势/占比 → \`chart\`（≤8 点）或 \`echart\`（多序列/要交互时）；数据多时给 \`table\`/\`chart\`/\`list\` 配一个 \`input\`(id) + \`filter\` 绑定，读者能就地筛选，不用再问一遍
+- 趋势/占比 → \`chart\`（≤8 点）或 \`echart\`（多序列/要交互时）；排版用 grid 子节点的 \`"span":2\` 跨列做宽窄混排（bento），不要一列方块堆到底；数据多时给 \`table\`/\`chart\`/\`list\` 配一个 \`input\`(id) + \`filter\` 绑定，读者能就地筛选，不用再问一遍
 - 正文以组件承载为主：能结构化的段落一律换成组件，文字只做连接与结论，同一份信息不要既写文字又重复出组件。
 
 **字段速查**（完整见 genui skill）：\`stat\` \`{"label":"…","value":"…","delta":"+1.2%"}\` · \`table\` \`{"columns":["…"],"rows":[["…"]],"types":["…"]?,"total":true?,"details":[[…]]?,"filter":"输入框id"?,"sortField":"下拉id"?}\` · \`callout\` \`{"tone":"info|success|warning|error","title":"…","content":"…"}\` · \`progress\` \`{"value":72,"variant":"ring"?,"target":80?}\`

--- a/tests/genui-v29.spec.tsx
+++ b/tests/genui-v29.spec.tsx
@@ -29,6 +29,33 @@ function renderBlock(spec: unknown, actions: Array<[string, Record<string, unkno
   )
 }
 
+describe('v13: hero 封面块与 bento 跨列', () => {
+  it('renders a hero with its metric, title, subtitle and tone', () => {
+    const { container } = renderBlock({
+      items: [{ type: 'hero', label: '可用率', value: '99.96%', delta: '+0.02%', tone: 'success', title: '服务健康', subtitle: '近 30 天' }],
+    })
+    const hero = container.querySelector('[class*="hero"]') as HTMLElement
+    expect(hero).not.toBeNull()
+    expect(hero.className).toContain('heroSuccess')
+    expect(container.textContent).toContain('可用率')
+    expect(container.textContent).toContain('服务健康')
+    expect(container.textContent).toContain('近 30 天')
+  })
+
+  it('spans grid columns for bento layouts', () => {
+    const { container } = renderBlock({
+      items: [{ type: 'grid', cols: 3, items: [
+        { type: 'card', span: 2, title: '宽卡', items: [{ type: 'text', content: 'a' }] },
+        { type: 'card', title: '窄卡', items: [{ type: 'text', content: 'b' }] },
+      ] }],
+    })
+    const spanned = container.querySelector('[class*="gridSpan"]') as HTMLElement
+    expect(spanned).not.toBeNull()
+    expect(spanned.style.gridColumn).toBe('span 2')
+    expect(container.querySelectorAll('[class*="gridSpan"]')).toHaveLength(1)
+  })
+})
+
 describe('v12: 本地数据绑定（就地筛选）', () => {
   it('filters table rows from a bound input, live', () => {
     const { container } = renderBlock({


### PR DESCRIPTION
「还是不能让人眼前一亮」的根因不是组件不够，而是**没有构图**——每条回答都是一列等宽方块往下堆。\n\n- **hero**：封面块。eyebrow + 52px 超大数字（入场计数）+ delta 芯片 + sparkline + 标题 + 副标题，四种 tone 各带一层很淡的渐变底色；一条回答最多一个，放最前面。\n- **span**：任意节点可加 `"span":2`，作为 grid 子节点时跨列 → bento 宽窄混排。guard 统一保留该字段，新组件不会漏。\n- **数字入场**：hero 与 `stat.size:"hero"` 从 0 计数到目标（720ms 三次缓出），尊重 prefers-reduced-motion；普通 stat 不动画。\n\n验证：tsc · 526 测试 · 构建 · 视觉 E2E 全绿。