### PR TITLE
fix(layout): bento 行里卡片内容不再留死空

### DIFF
--- a/src/client/GenuiBlock.module.css
+++ b/src/client/GenuiBlock.module.css
@@ -118,7 +118,18 @@
   display: flex;
   flex-direction: column;
   gap: var(--dsl-g-gap-md);
+  min-width: 0;
 }
+/* Bento rows size every card to the tallest one. Without this, a short card
+   (a single donut next to a tall table) kept its content pinned to the top and
+   left a large dead block underneath. The last child absorbs the extra height,
+   and the graphic shapes centre themselves inside it. */
+.card > :last-child { flex: 1 1 auto; min-height: 0; }
+.card > .chart,
+.card > .lineChart,
+.card > .donut,
+.card > .hbars { justify-content: center; }
+.card > .col { justify-content: center; }
 
 .cardTitle {
   font-size: var(--dsl-g-font-meta);
@@ -896,7 +907,7 @@
 .donutSeg:hover { filter: brightness(1.18); }
 .donutTotal { fill: var(--dsw-alias-label-primary); font-size: var(--dsl-g-font-h2); font-weight: 700; }
 .donutTotalLabel { fill: var(--dsw-alias-label-tertiary); font-size: 10px; }
-.donutLegend { display: flex; flex-direction: column; gap: var(--dsl-g-gap-sm); font-size: var(--dsl-g-font-meta); color: var(--dsw-alias-label-secondary); line-height: 1.5; }
+.donutLegend { display: flex; flex-direction: column; justify-content: center; gap: var(--dsl-g-gap-sm); font-size: var(--dsl-g-font-meta); color: var(--dsw-alias-label-secondary); line-height: 1.5; }
 .donutPct { color: var(--dsw-alias-label-tertiary); font-variant-numeric: tabular-nums; }
 
 /* ---------- progress ring + target marker ---------- */

--- a/src/client/gallery.ts
+++ b/src/client/gallery.ts
@@ -11,8 +11,12 @@ export const gallerySpec: GenuiSpec = {
   items: [
     { type: 'hero', label: '可用率 · 近 30 天', value: '99.96%', delta: '+0.02%', tone: 'accent', spark: [99.8, 99.85, 99.9, 99.88, 99.94, 99.96], title: 'hero 封面块', subtitle: '一条回答最多一个：eyebrow + 超大数字 + 标题 + 副标题，带 tone 渐变底色。' },
     { type: 'grid', cols: 3, items: [
-      { type: 'card', span: 2, title: 'span:2 的卡片', items: [{ type: 'text', size: 'body', content: 'grid 子节点加 span 就能跨列——bento 排版靠它：一张宽卡 + 一张窄卡。' }] },
-      { type: 'card', title: 'span:1', items: [{ type: 'text', size: 'body', content: '默认占一列。' }] },
+      { type: 'card', span: 2, title: 'span:2 · 宽卡', items: [
+        { type: 'text', size: 'body', content: 'grid 子节点加 span 就能跨列：一张宽卡 + 一张窄卡。卡片高度由该行最高的一张决定，内容会自动撑满或居中。' },
+        { type: 'chart', kind: 'line', data: [], series: [
+          { label: '本周', data: [{ label: '一', value: 8 }, { label: '二', value: 12 }, { label: '三', value: 9 }, { label: '四', value: 14 }] },
+          { label: '上周', data: [{ label: '一', value: 6 }, { label: '二', value: 9 }, { label: '三', value: 7 }, { label: '四', value: 10 }] }] }] },
+      { type: 'card', title: 'span:1', items: [{ type: 'chart', kind: 'donut', data: [{ label: '视觉', value: 42 }, { label: '采纳', value: 33 }, { label: '可靠', value: 25 }] }] },
     ] },
     { type: 'text', size: 'h1', content: '排版层级' },
     { type: 'text', size: 'h2', content: '二级标题' },

--- a/tests/genui-file-tree.spec.tsx
+++ b/tests/genui-file-tree.spec.tsx
@@ -85,6 +85,19 @@ function assertFileTreeLayout(container: HTMLElement): void {
   expect(container.textContent).toContain('README.md')
 }
 
+describe('bento card layout contract', () => {
+  it('lets a card absorb the row height and centre its graphic', () => {
+    const css = readFileSync(join(process.cwd(), 'src/client/GenuiBlock.module.css'), 'utf8')
+    // A short card next to a tall one used to pin its content to the top and
+    // leave a dead block underneath; the last child must absorb the slack and
+    // the graphic shapes must centre inside it.
+    expect(css).toMatch(/\.card > :last-child \{[^}]*flex: 1 1 auto/)
+    const centring = /\.card > \.chart,[\s\S]{0,120}?justify-content: center/
+    expect(css).toMatch(centring)
+    expect(css).toMatch(/\.gridSpan \{[^}]*display: flex/)
+  })
+})
+
 describe('GenUI file-tree layout (issue #28)', () => {
   it.skipIf(!hasFenceRegistry)('renders rows, indent and glyphs through the MarkdownText fence harness', () => {
     const { container } = render(<MarkdownText text={fenced({ items: [fileTree] })} />)


### PR DESCRIPTION
反馈截图：环形图卡片放在 2 列 bento 里，旁边是更高的表格卡，网格行高由最高卡片决定 → 环形图贴顶、下面一大块空白。\n\n- `.card > :last-child { flex: 1 1 auto; min-height: 0 }`：最后一个元素吸收多余高度。\n- `.card > .chart / .lineChart / .donut / .hbars / .col` 撑开后居中（图例同样居中）。\n- gallery 的示例宽卡从两行字换成带折线图的内容卡。\n- 新增 CSS 契约测试钉住这三条规则。\n\n验证：tsc · 527 测试 · 构建 · 视觉 E2E 全绿。