### PR TITLE
fix(echart): 主题令牌读错节点导致多序列图全是蓝色

### DIFF
--- a/scripts/e2e-visual.mts
+++ b/scripts/e2e-visual.mts
@@ -336,6 +336,36 @@ try {
   if (!treeCheck.ok) throw new Error(`文件树没有纵向堆叠（${treeCheck.reason}）`)
   log(`✓ 文件树：${treeCheck.rows} 行纵向堆叠 · ${treeCheck.guides} 条层级引导线 · ${treeCheck.glyphs} 个图标`)
 
+  // ── ECharts 配色验证（读 canvas 像素）────────────────────────────────────
+  // 回归：宿主把 --dsw-static-* 定义在 body 上，而引擎只从 :root 读 → 每个
+  // 系列都回退成同一个强调色，多序列图全是一片蓝。这里直接数像素色数。
+  const hueCheck = await page.evaluate(() => {
+    const canvases = [...document.querySelectorAll('[data-genui-echart] canvas')] as HTMLCanvasElement[]
+    const target = canvases[1] ?? canvases[0]
+    if (target === undefined) return { ok: false, reason: '没有 canvas' }
+    const ctx = target.getContext('2d')
+    if (ctx === null) return { ok: false, reason: '没有 2d 上下文' }
+    const { data } = ctx.getImageData(0, 0, target.width, target.height)
+    const hues = new Set<string>()
+    let saturated = 0
+    for (let i = 0; i < data.length; i += 4 * 37) {
+      const r = data[i] ?? 0
+      const g = data[i + 1] ?? 0
+      const b = data[i + 2] ?? 0
+      if ((data[i + 3] ?? 0) < 200) continue
+      // Only count SATURATED pixels: greys are axes/labels/background and would
+      // let a single-colour chart pass this check.
+      if (Math.max(r, g, b) - Math.min(r, g, b) < 40) continue
+      saturated += 1
+      hues.add(`${r >> 5}-${g >> 5}-${b >> 5}`)
+    }
+    // The radar preset draws two series: two distinct saturated hues are the
+    // minimum proof that the palette did not collapse to one accent colour.
+    return { ok: hues.size >= 2 && saturated >= 20, hues: hues.size, saturated, canvases: canvases.length }
+  })
+  if (!hueCheck.ok) throw new Error(`ECharts 配色异常（${JSON.stringify(hueCheck)}）`)
+  log(`✓ ECharts 配色：${hueCheck.canvases} 张画布，雷达图 ${hueCheck.hues} 种饱和色（${hueCheck.saturated} 像素）`)
+
   // ── 图表 tooltip 验证（真实 hover）────────────────────────────────────────
   const stackSeg = page.locator('[class*="stackSeg"]').first()
   if (await stackSeg.count() > 0) {

--- a/src/client/EChartNode.tsx
+++ b/src/client/EChartNode.tsx
@@ -23,14 +23,35 @@ function neededEngine(node: GenuiEChart): 'core' | 'full' {
   return CORE_PRESETS.has(node.preset ?? 'bar') ? 'core' : 'full'
 }
 
-/** Read a CSS custom property from the document root (host theme token). */
-function readToken(name: string, fallback: string): string {
-  const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim()
-  return v || fallback
+/**
+ * Categorical fallback palette. The host defines its `--dsw-static-*` tokens on
+ * `body`, not on `:root`, and ECharts renders to CANVAS (so a `var(--x)` string
+ * is meaningless to it — every colour must be resolved to a literal first).
+ * Reading only `document.documentElement` therefore returned '' for every
+ * series colour and collapsed multi-series charts to one accent hue; these
+ * fixed hues keep series distinguishable on any host.
+ */
+export const SERIES_FALLBACK = [
+  '#679efe', '#4ed17e', '#f5b83d', '#f2707a', '#8b7ff0', '#3fc7d4', '#b7c8fe', '#9aa3b2',
+] as const
+
+/**
+ * Read a host theme token, resolved from the ELEMENT first (custom properties
+ * inherit, so any node inside `body` sees the host sheet) and falling back to
+ * body/root for detached renders.
+ */
+function readToken(name: string, fallback: string, el?: HTMLElement | null): string {
+  const hosts: Array<Element | null> = [el ?? null, typeof document === 'undefined' ? null : document.body, typeof document === 'undefined' ? null : document.documentElement]
+  for (const host of hosts) {
+    if (host === null) continue
+    const value = getComputedStyle(host).getPropertyValue(name).trim()
+    if (value !== '') return value
+  }
+  return fallback
 }
 
 /** Resolve the host accent and label colors for ECharts theming. */
-function themeColors(): {
+function themeColors(el?: HTMLElement | null): {
   accent: string
   labelPrimary: string
   labelSecondary: string
@@ -39,19 +60,25 @@ function themeColors(): {
   bgLayer1: string
 } {
   return {
-    accent: readToken('--dsw-alias-state-business-primary', '#4f8ef7'),
-    labelPrimary: readToken('--dsw-alias-label-primary', '#e6e6e6'),
-    labelSecondary: readToken('--dsw-alias-label-secondary', '#a0a0a0'),
-    labelTertiary: readToken('--dsw-alias-label-tertiary', '#6b6b6b'),
-    border: readToken('--dsw-alias-border-l1', 'rgba(255,255,255,0.12)'),
-    bgLayer1: readToken('--dsw-alias-bg-layer-1', '#1a1a1e'),
+    accent: readToken('--dsw-alias-state-business-primary', '#4f8ef7', el),
+    labelPrimary: readToken('--dsw-alias-label-primary', '#e6e6e6', el),
+    labelSecondary: readToken('--dsw-alias-label-secondary', '#a0a0a0', el),
+    labelTertiary: readToken('--dsw-alias-label-tertiary', '#6b6b6b', el),
+    border: readToken('--dsw-alias-border-l1', 'rgba(255,255,255,0.12)', el),
+    bgLayer1: readToken('--dsw-alias-bg-layer-1', '#1a1a1e', el),
   }
 }
 
-/** Build a full ECharts option from a preset + the simple data/series shape. */
-function presetOption(node: GenuiEChart): Record<string, unknown> {
-  const t = themeColors()
-  const colors = CHART_COLORS.map(c => readToken(c.replace('var(', '').replace(')', ''), t.accent))
+/** Build a full ECharts option from a preset + the simple data/series shape.
+ *  `el` is the chart's own container: theme tokens are resolved against it so
+ *  host colours are found wherever the host defines them. */
+function presetOption(node: GenuiEChart, el?: HTMLElement | null): Record<string, unknown> {
+  const t = themeColors(el)
+  // Each palette slot carries its own fallback hue: if the host lacks the
+  // static tokens, series must still be distinguishable (the old code fell
+  // back to the accent for every slot, so every chart came out one colour).
+  const colors = CHART_COLORS.map((c, i) =>
+    readToken(c.replace('var(', '').replace(')', ''), SERIES_FALLBACK[i % SERIES_FALLBACK.length]!, el))
   const data = node.data ?? []
   const series = node.series
 
@@ -356,7 +383,7 @@ export function EChartNode({ node }: { node: GenuiEChart }) {
     if (el === null) return
 
     // Full `option` wins over preset shorthand.
-    const option = node.option ?? presetOption(node)
+    const option = node.option ?? presetOption(node, el)
 
     void lazyCreateChart(el, option, { height: node.height ?? 300 }, neededEngine(node)).then((inst) => {
       if (!alive) {
@@ -397,7 +424,7 @@ export function EChartNode({ node }: { node: GenuiEChart }) {
   // returned early when status was 'loading' and never re-run).
   useEffect(() => {
     if (status !== 'ready' || instanceRef.current === null) return
-    const option = node.option ?? presetOption(node)
+    const option = node.option ?? presetOption(node, ref.current)
     instanceRef.current.setOption(option, true)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [node, status])

--- a/tests/genui-echart.spec.tsx
+++ b/tests/genui-echart.spec.tsx
@@ -4,7 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, render } from '@testing-library/react'
 import type { GenuiEChart } from '../src/client/spec'
-import { EChartNode } from '../src/client/EChartNode.tsx'
+import { EChartNode, SERIES_FALLBACK } from '../src/client/EChartNode.tsx'
 import { createChart } from '../src/client/echarts-lazy.ts'
 
 vi.mock('../src/client/echarts-lazy.ts', async () => {
@@ -22,6 +22,15 @@ afterEach(() => {
 function fakeInstance() {
   return { setOption: vi.fn(), resize: vi.fn(), dispose: vi.fn() }
 }
+
+describe('EChartNode: series palette', () => {
+  it('keeps eight distinct fallback hues (host tokens may be absent)', () => {
+    // The regression: every slot fell back to the single accent colour, so a
+    // multi-series chart came out entirely blue.
+    expect(SERIES_FALLBACK.length).toBeGreaterThanOrEqual(6)
+    expect(new Set(SERIES_FALLBACK).size).toBe(SERIES_FALLBACK.length)
+  })
+})
 
 describe('EChartNode: preset rendering', () => {
   it('renders data-genui-echart container for each preset', async () => {


### PR DESCRIPTION
截图反馈「全是蓝的，有的图不应该」。\n\n**根因**：宿主把 `--dsw-static-*`（分类色板）定义在 **body** 上，而 EChartNode 只从 `document.documentElement` 读。ECharts 渲染到 canvas，`var(--x)` 对它没有意义、必须先解析成字面值——读不到就每个槽位都回退到同一个强调色，多序列图整片蓝。原生 `chart` 不受影响（颜色交给 CSS 解析）。\n\n**修法**：\n- `readToken` 按「图表元素 → body → :root」逐级解析；\n- 色板槽位各自带独立回退色（8 个固定色相），宿主缺色板时系列仍可区分；\n- `presetOption(node, el)` 挂载与更新两条路径都传当前元素。\n\n**回归防线**：单测断言回退色板 ≥6 色且互不相同；视觉 E2E 新增读 canvas 像素的断言——雷达图必须出现 ≥2 种饱和色（跳过灰阶，否则单色图能蒙混过关）。\n\n验证：tsc · 532 测试 · 构建 · 视觉 E2E 全绿。