### PR TITLE
feat(spec): 图表调色板、卡片强调色、表格导出

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -24,7 +24,8 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 - grid: `{"type":"grid","cols":n,"items":[...]}`
 - hero: `{"type":"hero","title":"...","subtitle":"...","value":"99.96%","label":"可用率","delta":"+0.02%","spark":[...],"tone":"accent|success|warning|danger"}` — **封面块**：eyebrow + 超大数字（52px，带入场计数）+ 标题 + 副标题 + tone 渐变底色。**一条回答最多用一个**，放在最前面当视觉锚点
 - span: 任意节点都可加 `"span":2`（grid 子节点占几列）——bento 排版的唯一原语：一张 `span:2` 宽卡配一张窄卡，比一列方块堆下去好看得多
-- card: `{"type":"card","title":"...","items":[...]}`；`"tone":"info|success|warning|danger"` 给卡片底色（用于结论卡/风险卡）
+- card: `{"type":"card","title":"...","items":[...]}`；`"accent":"#f59e0b"` 指定强调色（边框 + 标题 + 极淡底色）
+- palette: `chart` / `echart` 都支持 `"palette":["#ff8800","#3ecf8e"]` 覆盖分类色板（默认跟随宿主主题）。**只有语义上需要指定颜色时才写**（成本=红、收益=绿），否则跟随主题更稳；`"tone":"info|success|warning|danger"` 给卡片底色（用于结论卡/风险卡）
 - divider: `{"type":"divider"}`; spacer: `{"type":"spacer"}`
 
 ### 展示
@@ -36,7 +37,7 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 - audio: `{"type":"audio","src":"/mmx-files/result.mp3","alt":"语音结果","loop":true?}` — 原生控制条；用户主动播放，不自动播放；仅 http(s) 或同源相对地址
 - video: `{"type":"video","src":"/mmx-files/result.mp4","alt":"视频结果","poster":"/mmx-files/poster.jpg"?,"loop":true?,"muted":true?,"aspectRatio":"16:9|4:3|1:1|9:16"?}` — 原生播放/音量/全屏控制；不自动播放
 - list: `{"type":"list","items":["..."] 或 [{"title":"...","desc":"..."}] 或嵌套节点(如 {"type":"badge","label":"TS"})}` — 行内可嵌节点（计入节点预算）
-- table: `{"type":"table","columns":["..."],"rows":[["...","..."]],"types":["text|num|delta|bar|badge"]?,"details":[[...]]?,"total":true?}` — 表头点击本地排序（升/降/还原，零往返）；数值感知：千分位（`1,234`）、`k/m/b`、`万/亿`、`%`、货币符号都能按真实数值比较，纯数值列自动右对齐；**带符号单元格自动着色**（`+12.4%` 绿、`-3` 红，无需额外字段）；`types` 可按列指定 `bar`（0-100 内联进度条）、`ring`（0-100 小环）、`spark`（单元格写 `"3,5,4,8"` 画微趋势线）、`badge`（胶囊标签）、`delta`（强制涨跌色）、`num`（强制右对齐）、`index`（行号）、`group`（首列当分组标题：该行只有第一格有内容时渲染成跨列小标题）；`"total":true` 追加合计行（数值列自动求和）；**`"filter":"输入框id"`**：把表格和某个 input/select 绑定，读者输入即时过滤（`filterColumn` 可限定列）——数据多时**默认就该配一个**；**`"sortField":"下拉id"`** 用下拉的值（列名）排序；**`"details"` 与 rows 同序**，第 i 项是该行展开后的内容（可放任意组件，`null` = 该行不可展开）——首列出现 chevron，点开在整行下方展开明细，适合「主表 + 明细」
+- table: `{"type":"table","columns":["..."],"rows":[["...","..."]],"types":["text|num|delta|bar|badge"]?,"details":[[...]]?,"total":true?}` — 表头点击本地排序（升/降/还原，零往返）；数值感知：千分位（`1,234`）、`k/m/b`、`万/亿`、`%`、货币符号都能按真实数值比较，纯数值列自动右对齐；**带符号单元格自动着色**（`+12.4%` 绿、`-3` 红，无需额外字段）；`types` 可按列指定 `bar`（0-100 内联进度条）、`ring`（0-100 小环）、`spark`（单元格写 `"3,5,4,8"` 画微趋势线）、`badge`（胶囊标签）、`delta`（强制涨跌色）、`num`（强制右对齐）、`index`（行号）、`group`（首列当分组标题：该行只有第一格有内容时渲染成跨列小标题）；`"total":true` 追加合计行（数值列自动求和）；**`"export":true`**：表格上方出现「复制 Markdown / 复制 CSV」两个小按钮（纯本地剪贴板，不发请求）；**`"filter":"输入框id"`**：把表格和某个 input/select 绑定，读者输入即时过滤（`filterColumn` 可限定列）——数据多时**默认就该配一个**；**`"sortField":"下拉id"`** 用下拉的值（列名）排序；**`"details"` 与 rows 同序**，第 i 项是该行展开后的内容（可放任意组件，`null` = 该行不可展开）——首列出现 chevron，点开在整行下方展开明细，适合「主表 + 明细」
 - keyvalue: `{"type":"keyvalue","pairs":[{"key":"...","value":"..."}]}`
 - timeline: `{"type":"timeline","items":[{"title":"...","desc":"...","time":"..."}]}`
 - file-tree: `{"type":"file-tree","items":[{"name":"...","type":"file|dir","children":[...]?}]}` — 目录行可点击折叠/展开（本地，零往返）

--- a/src/client/EChartNode.tsx
+++ b/src/client/EChartNode.tsx
@@ -77,8 +77,10 @@ function presetOption(node: GenuiEChart, el?: HTMLElement | null): Record<string
   // Each palette slot carries its own fallback hue: if the host lacks the
   // static tokens, series must still be distinguishable (the old code fell
   // back to the accent for every slot, so every chart came out one colour).
-  const colors = CHART_COLORS.map((c, i) =>
-    readToken(c.replace('var(', '').replace(')', ''), SERIES_FALLBACK[i % SERIES_FALLBACK.length]!, el))
+  const colors = node.palette !== undefined && node.palette.length > 0
+    ? [...node.palette]
+    : CHART_COLORS.map((c, i) =>
+      readToken(c.replace('var(', '').replace(')', ''), SERIES_FALLBACK[i % SERIES_FALLBACK.length]!, el))
   const data = node.data ?? []
   const series = node.series
 

--- a/src/client/GenuiBlock.module.css
+++ b/src/client/GenuiBlock.module.css
@@ -954,6 +954,30 @@
   font-size: var(--dsl-g-font-meta);
 }
 
+/* Export chips (`table.export`): a quiet toolbar above the table. */
+.tableTools {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 6px 8px 4px;
+}
+.tableTool {
+  padding: 2px 9px;
+  border: 1px solid var(--dsl-g-border);
+  border-radius: var(--dsl-g-radius-pill);
+  background: transparent;
+  color: var(--dsw-alias-label-secondary);
+  font-family: inherit;
+  font-size: var(--dsl-g-font-meta);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.tableTool:hover { color: var(--dsw-alias-label-primary); border-color: var(--dsl-g-border-strong); background: var(--dsl-g-hover); }
+.tableTool:focus-visible { outline: 2px solid var(--dsl-g-accent); outline-offset: 1px; }
+/* Card accent (`card.accent`): the border/wash come in inline; the title picks
+   up the same hue through this variable. */
+.card[style*="--dsl-card-accent"] > .cardTitle { color: var(--dsl-card-accent); }
+
 /* Master-detail rows (table.details): a chevron in the first cell opens a
    full-width panel underneath, so a table can drill down without leaving the
    page or opening a modal. */

--- a/src/client/blocks/charts.tsx
+++ b/src/client/blocks/charts.tsx
@@ -12,6 +12,7 @@
  */
 import { Fragment, memo, useCallback, useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { MouseEvent as ReactMouseEvent, ReactNode, RefObject } from 'react'
+import { writeClipboard } from '@deepseek-ai/dsh-client-ui-primitives'
 import css from '../GenuiBlock.module.css'
 import { GENUI_LIMITS } from '../genui-runtime/index.ts'
 import type { GenuiChart, GenuiTable } from '../spec.ts'
@@ -27,9 +28,12 @@ export const CHART_COLORS = [
   'var(--dsw-static-deepseek-300)',
 ]
 
-/** Series color: explicit color wins; multi-series auto-assign from the palette. */
-const seriesColor = (i: number, n: number, c?: string): string | undefined =>
-  c ?? (n > 1 ? CHART_COLORS[i % CHART_COLORS.length] : undefined)
+/** Series color: explicit color wins; then an explicit `palette` from the
+ *  spec; then the host categorical tokens. */
+const seriesColor = (i: number, n: number, c?: string, palette?: readonly string[]): string | undefined =>
+  c ?? (palette !== undefined && palette.length > 0
+    ? palette[i % palette.length]
+    : n > 1 ? CHART_COLORS[i % CHART_COLORS.length] : undefined)
 
 /**
  * Sortable numeric value of a cell. Human-written table cells are rarely
@@ -128,6 +132,48 @@ function CellRing({ cell }: { cell: string | number }) {
       </svg>
       <span className={css.cellRingText}>{String(cell)}</span>
     </span>
+  )
+}
+
+/** Markdown table text for the 复制 Markdown chip (pipes escaped). */
+export function tableToMarkdown(columns: string[], rows: Array<Array<string | number>>): string {
+  const escape = (v: unknown): string => String(v ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ')
+  const head = `| ${columns.map(escape).join(' | ')} |`
+  const rule = `| ${columns.map(() => '---').join(' | ')} |`
+  const body = rows.map(row => `| ${columns.map((_c, i) => escape(row[i])).join(' | ')} |`)
+  return [head, rule, ...body].join('\n')
+}
+
+/** RFC 4180 CSV text for the 复制 CSV chip. */
+export function tableToCsv(rows: Array<Array<string | number>>): string {
+  const cell = (v: unknown): string => {
+    const s = String(v ?? '')
+    return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+  }
+  return rows.map(row => row.map(cell).join(',')).join('\n')
+}
+
+/** Copy chips above a table (`table.export`). Local clipboard only — no action,
+ *  no round trip; the label confirms for a moment and then resets. */
+function TableExportChips({ columns, rows }: { columns: string[]; rows: Array<Array<string | number>> }) {
+  const [copied, setCopied] = useState<'md' | 'csv' | null>(null)
+  const copy = (kind: 'md' | 'csv'): void => {
+    const text = kind === 'md' ? tableToMarkdown(columns, rows) : tableToCsv(rows)
+    void writeClipboard(text).then(ok => {
+      if (!ok) return
+      setCopied(kind)
+      window.setTimeout(() => setCopied(null), 1200)
+    })
+  }
+  return (
+    <div className={css.tableTools}>
+      <button type="button" className={css.tableTool} onClick={() => copy('md')}>
+        {copied === 'md' ? '已复制' : '复制 Markdown'}
+      </button>
+      <button type="button" className={css.tableTool} onClick={() => copy('csv')}>
+        {copied === 'csv' ? '已复制' : '复制 CSV'}
+      </button>
+    </div>
   )
 }
 
@@ -280,6 +326,7 @@ export const TableNode = memo(function TableNode({ node, renderDetail, filterVal
 
   return (
     <div className={css.tableWrap}>
+      {node.export === true && <TableExportChips columns={columns} rows={rows} />}
       <table className={css.table}>
         <thead>
           <tr>
@@ -528,7 +575,7 @@ export const BarsNode = memo(function BarsNode({ chart }: { chart: GenuiChart })
     ? grouped.map(s => s.data.map(d => Number(d.value) || 0))
     : [data.map(d => Number(d.value) || 0)]
   const colors = seriesValues.map((_values, si) =>
-    seriesColor(si, seriesValues.length, isGrouped ? grouped[si]?.color : undefined) ?? 'var(--dsw-alias-state-business-primary, #4f8ef7)')
+    seriesColor(si, seriesValues.length, isGrouped ? grouped[si]?.color : undefined, chart.palette) ?? 'var(--dsw-alias-state-business-primary, #4f8ef7)')
   const flat = seriesValues.flat()
   const showValues = labels.length <= 12
   const stacked = chart.stacked === true && isGrouped
@@ -739,7 +786,7 @@ export const LineChartNode = memo(function LineChartNode({ chart }: { chart: Gen
     ? grouped.map(entry => entry.data.map(d => Number(d.value) || 0))
     : [data.map(d => Number(d.value) || 0)]
   const colors = seriesValues.map((_values, si) =>
-    seriesColor(si, seriesValues.length, grouped !== undefined ? grouped[si]?.color : undefined) ?? 'var(--dsl-g-accent)')
+    seriesColor(si, seriesValues.length, grouped !== undefined ? grouped[si]?.color : undefined, chart.palette) ?? 'var(--dsl-g-accent)')
   const multi = seriesValues.length > 1
   const flat = seriesValues.flat()
   const pointCount = Math.max(...seriesValues.map(values => values.length), 0)
@@ -858,7 +905,7 @@ export const DonutNode = memo(function DonutNode({ chart }: { chart: GenuiChart 
               fill="none"
               strokeWidth={STROKE}
               className={css.donutSeg}
-              style={{ stroke: seriesColor(i, data.length, d.color) ?? 'var(--dsw-alias-state-business-primary, #4f8ef7)' }}
+              style={{ stroke: seriesColor(i, data.length, d.color, chart.palette) ?? 'var(--dsw-alias-state-business-primary, #4f8ef7)' }}
               strokeDasharray={`${len} ${C - len}`}
               strokeDashoffset={-offset}
               transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
@@ -875,7 +922,7 @@ export const DonutNode = memo(function DonutNode({ chart }: { chart: GenuiChart 
       <div className={css.donutLegend}>
         {clamped.map((d, i) => (
           <span key={i} className={css.legendItem}>
-            <span className={css.legendSwatch} style={{ background: seriesColor(i, data.length, d.color) ?? 'var(--dsw-alias-state-business-primary, #4f8ef7)' }} />
+            <span className={css.legendSwatch} style={{ background: seriesColor(i, data.length, d.color, chart.palette) ?? 'var(--dsw-alias-state-business-primary, #4f8ef7)' }} />
             <span>{d.label}</span>
             <span className={css.donutPct}>{String(d.value)} · {(d.v / total * 100).toFixed(1)}%</span>
           </span>

--- a/src/client/blocks/render-node.tsx
+++ b/src/client/blocks/render-node.tsx
@@ -4,7 +4,7 @@
  * the sibling block modules. Depth-guarded against pathological specs.
  * @module @changfenhuang/dsh-genui/client/blocks/render-node
  */
-import { type ComponentType, type ReactNode, useEffect, useState } from 'react'
+import { type ComponentType, type ReactNode, useEffect, useState, type CSSProperties } from 'react'
 import * as primitives from '@deepseek-ai/dsh-client-ui-primitives'
 import css from '../GenuiBlock.module.css'
 import { GENUI_LIMITS } from '../genui-runtime/index.ts'
@@ -238,8 +238,15 @@ export function renderNode(
     }
     case 'card': {
       const toneClass = node.tone === undefined ? '' : ` ${css[`card${node.tone[0]!.toUpperCase()}${node.tone.slice(1)}`] ?? ''}`
+      // An explicit accent drives border + title + a very light wash; it is a
+      // colour hint, not a layout change, so it composes with tone.
+      const accentStyle = node.accent === undefined ? undefined : {
+        borderColor: `color-mix(in srgb, ${node.accent} 45%, transparent)`,
+        background: `color-mix(in srgb, ${node.accent} 7%, var(--dsw-alias-bg-layer-1, transparent))`,
+        '--dsl-card-accent': node.accent,
+      } as CSSProperties
       return (
-        <div key={key} className={`${css.card}${toneClass}`}>
+        <div key={key} className={`${css.card}${toneClass}`} style={accentStyle}>
           {node.title !== undefined && <div className={css.cardTitle}>{node.title}</div>}
           {node.items.map((c, i) => renderNode(c, i, onAction, depth + 1, answers))}
         </div>

--- a/src/client/genui-runtime/schema.ts
+++ b/src/client/genui-runtime/schema.ts
@@ -246,7 +246,7 @@ export const COMPONENT_SCHEMAS: Readonly<Record<string, ComponentSchema>> = {
   breadcrumb: schema(['items'], { ...nodeFields, items: 'array' }),
   button: schema(['label'], { ...nodeFields, label: 'string', tone: 'string', full: 'boolean', small: 'boolean', icon: 'string', action: 'string' }, {}, { enums: { tone: BUTTON_TONES } }),
   callout: schema(['content'], { ...nodeFields, title: 'string', content: 'string', tone: 'string' }, { kind: 'tone' }, { enums: { tone: CALLOUT_TONES } }),
-  card: schema(['items'], { ...nodeFields, title: 'string', items: 'nodes', tone: 'string' }, { label: 'title', content: 'items' }, { enums: { tone: CARD_TONES } }),
+  card: schema(['items'], { ...nodeFields, title: 'string', items: 'nodes', tone: 'string', accent: 'string' }, { label: 'title', content: 'items' }, { enums: { tone: CARD_TONES } }),
   chart: schema([], {
     ...nodeFields,
     kind: 'string',
@@ -255,6 +255,7 @@ export const COMPONENT_SCHEMAS: Readonly<Record<string, ComponentSchema>> = {
     horizontal: 'boolean',
     stacked: 'boolean',
     filter: 'string',
+    palette: 'array',
   }, {}, {
     oneOfRequired: [['data', 'series']],
     // `line` may carry its points in `series` (multi-series line); only the
@@ -276,7 +277,7 @@ export const COMPONENT_SCHEMAS: Readonly<Record<string, ComponentSchema>> = {
   }),
   diff: schema(['diffs'], { ...nodeFields, diffs: 'array' }, {}, { nested: { diffs: diffRecordSchema } }),
   divider: schema([], nodeFields),
-  echart: schema([], { ...nodeFields, title: 'string', height: 'number', preset: 'string', data: 'array', series: 'array', links: 'array', option: 'object' }, {}, {
+  echart: schema([], { ...nodeFields, title: 'string', height: 'number', preset: 'string', data: 'array', series: 'array', links: 'array', palette: 'array', option: 'object' }, {}, {
     // `links` alone is valid: the sankey/graph presets are edge-driven.
     oneOfRequired: [['option', 'data', 'series', 'links']],
     enums: { preset: ECHART_PRESETS },
@@ -313,7 +314,7 @@ export const COMPONENT_SCHEMAS: Readonly<Record<string, ComponentSchema>> = {
   steps: schema(['steps'], { ...nodeFields, steps: 'array', current: 'number' }, { items: 'steps' }, { nested: { steps: stepsRecordSchema } }),
   submit: schema(['label'], { ...nodeFields, label: 'string', action: 'string', resetAction: 'string', groups: 'array' }),
   switch: schema(['label'], { ...nodeFields, label: 'string', checked: 'boolean', action: 'string' }),
-  table: schema(['columns', 'rows'], { ...nodeFields, columns: 'array', rows: 'array', types: 'array', total: 'boolean', details: 'array', filter: 'string', filterColumn: 'number', sortField: 'string' }, { headers: 'columns', data: 'rows' }),
+  table: schema(['columns', 'rows'], { ...nodeFields, columns: 'array', rows: 'array', types: 'array', total: 'boolean', details: 'array', filter: 'string', filterColumn: 'number', sortField: 'string', export: 'boolean' }, { headers: 'columns', data: 'rows' }),
   tabs: schema(['tabs'], { ...nodeFields, tabs: 'array' }, {}, { nested: { tabs: tabHolderSchema } }),
   text: schema(['content'], { ...nodeFields, content: 'string', size: 'string', center: 'boolean' }, { text: 'content' }, { enums: { size: TEXT_SIZES } }),
   textarea: schema([], { ...nodeFields, label: 'string', placeholder: 'string', rows: 'number', value: 'string', action: 'string', id: 'string' }),

--- a/src/client/guard.ts
+++ b/src/client/guard.ts
@@ -209,6 +209,18 @@ function repairItems(list: unknown, ctx: RepairCtx, depth: number): GenuiNode[] 
   return out
 }
 
+/** Optional explicit palette: up to 12 validated colour values. */
+function paletteValues(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined
+  const out: string[] = []
+  for (const item of v.slice(0, 12)) {
+    const value = color(item)
+    if (value === undefined) continue
+    out.push(value)
+  }
+  return out.length > 0 ? out : undefined
+}
+
 /** Optional `stat.spark` series: finite numbers only, 2..60 points. */
 function sparkValues(v: unknown): number[] | undefined {
   if (!Array.isArray(v)) return undefined
@@ -258,6 +270,7 @@ function repairNodeFields(value: unknown, ctx: RepairCtx, depth: number): GenuiN
         items: repairItems(v.items, ctx, depth + 1),
         ...opt('title', str(v.title, GENUI_LIMITS.maxString)),
         ...opt('tone', enu(v.tone, CARD_TONES)),
+        ...opt('accent', color(v.accent)),
       }
     }
     case 'button': {
@@ -434,6 +447,7 @@ function repairNodeFields(value: unknown, ctx: RepairCtx, depth: number): GenuiN
         type: 'table', columns, rows,
         ...opt('types', types),
         ...opt('total', v.total === true ? true : undefined),
+        ...opt('export', v.export === true ? true : undefined),
         ...opt('filter', str(v.filter, 64)),
         ...opt('filterColumn', int(v.filterColumn, 0, GENUI_LIMITS.maxTableCols - 1)),
         ...opt('sortField', str(v.sortField, 64)),
@@ -454,6 +468,7 @@ function repairNodeFields(value: unknown, ctx: RepairCtx, depth: number): GenuiN
         ...opt('horizontal', v.horizontal === true ? true : undefined),
         ...opt('stacked', v.stacked === true ? true : undefined),
         ...opt('filter', str(v.filter, 64)),
+        ...opt('palette', paletteValues(v.palette)),
       }
     }
     case 'tabs': {
@@ -660,6 +675,7 @@ function repairNodeFields(value: unknown, ctx: RepairCtx, depth: number): GenuiN
         ...opt('data', data),
         ...opt('series', series),
         ...opt('links', links !== undefined && links.length > 0 ? links : undefined),
+        ...opt('palette', paletteValues(v.palette)),
         ...opt('option', option),
       }
     }

--- a/src/client/spec.ts
+++ b/src/client/spec.ts
@@ -279,6 +279,8 @@ export interface GenuiCard {
   title?: string
   /** Semantic tint for the card surface (default: neutral). */
   tone?: 'info' | 'success' | 'warning' | 'danger'
+  /** Explicit accent (hex) driving the border, title and wash. */
+  accent?: string
   items: GenuiNode[]
 }
 
@@ -297,6 +299,8 @@ export interface GenuiTable {
   types?: TableCellType[]
   /** Append a 合计 footer row (numeric columns are summed). */
   total?: boolean
+  /** Show 复制 Markdown / 复制 CSV chips above the table. */
+  export?: boolean
   /** Optional master-detail payload, positionally aligned with `rows`:
    *  `details[i]` is what row i expands into (omit / empty = not expandable). */
   details?: Array<GenuiNode[] | null>
@@ -333,6 +337,8 @@ export interface GenuiChart {
   horizontal?: boolean
   /** Bars + series: stack the series instead of grouping them. */
   stacked?: boolean
+  /** Explicit categorical palette (hex) — overrides the host theme colours. */
+  palette?: string[]
   /** Field id of an input/select: its value filters the categories locally. */
   filter?: string
 }
@@ -785,6 +791,8 @@ export interface GenuiEChart {
   series?: Array<{ label: string; color?: string; data: GenuiChartDatum[] }>
   /** Node/edge data for the `sankey` and `graph` presets. */
   links?: Array<{ from: string; to: string; value?: number }>
+  /** Explicit categorical palette (hex) for preset mode. */
+  palette?: string[]
   /** Full ECharts option object. When present, `preset`/`data`/`series` are
    * ignored. This is a pass-through to `echarts.setOption`. */
   option?: Record<string, unknown>

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -103,10 +103,10 @@ The spec is a white-listed component tree rendered inline where the fence sits. 
 **默认就该出 UI**：出现下列情况至少出一个围栏：
 - ≥3 条并列要点 → \`list\`；数字对比 → \`table\`；指标/进度/状态 → \`stat\`/\`progress\`/\`badge\`
 - 步骤/时间线 → \`steps\`/\`timeline\`/\`mermaid\`；架构/流程 → \`diagram\` 或 \`mermaid\`；风险/结论 → \`callout\`；代码/改动 → \`code\`/\`diff\`/\`json\`
-- 趋势/占比 → \`chart\`（≤8 点）或 \`echart\`（多序列/要交互时）；排版用 grid 子节点的 \`"span":2\` 跨列做宽窄混排（bento），不要一列方块堆到底；数据多时给 \`table\`/\`chart\`/\`list\` 配一个 \`input\`(id) + \`filter\` 绑定，读者能就地筛选，不用再问一遍
+- 趋势/占比 → \`chart\`（≤8 点）或 \`echart\`（多序列/要交互时）；配色默认跟随主题，只有语义需要时才用 \`palette\` / \`card.accent\`；排版用 grid 子节点的 \`"span":2\` 跨列做宽窄混排（bento），不要一列方块堆到底；数据多时给 \`table\`/\`chart\`/\`list\` 配一个 \`input\`(id) + \`filter\` 绑定，读者能就地筛选，不用再问一遍
 - 正文以组件承载为主：能结构化的段落一律换成组件，文字只做连接与结论，同一份信息不要既写文字又重复出组件。
 
-**字段速查**（完整见 genui skill）：\`stat\` \`{"label":"…","value":"…","delta":"+1.2%"}\` · \`table\` \`{"columns":["…"],"rows":[["…"]],"types":["…"]?,"total":true?,"details":[[…]]?,"filter":"输入框id"?,"sortField":"下拉id"?}\` · \`callout\` \`{"tone":"info|success|warning|error","title":"…","content":"…"}\` · \`progress\` \`{"value":72,"variant":"ring"?,"target":80?}\`
+**字段速查**（完整见 genui skill）：\`stat\` \`{"label":"…","value":"…","delta":"+1.2%"}\` · \`table\` \`{"columns":["…"],"rows":[["…"]],"types":["…"]?,"total":true?,"details":[[…]]?,"filter":"输入框id"?,"sortField":"下拉id"?,"export":true?}\` · \`callout\` \`{"tone":"info|success|warning|error","title":"…","content":"…"}\` · \`progress\` \`{"value":72,"variant":"ring"?,"target":80?}\`
 
 Rules:
 - JSON 严格: 坏围栏降级为代码块；≥3 节点或含 table 的围栏发出前调用 validate_dsh_ui，❌ 修好再发（若附「已自动修复」JSON 照抄即可）。

--- a/tests/genui-v29.spec.tsx
+++ b/tests/genui-v29.spec.tsx
@@ -12,6 +12,7 @@ import { GenuiActionContext } from '../src/client/action-context.ts'
 import { GenuiBlock, GENUI_ACTION_DEBOUNCE_MS } from '../src/client/GenuiBlock.tsx'
 import { repairGenuiSpec } from '../src/client/guard.ts'
 import { CORE_PRESETS } from '../src/client/echarts-lazy.ts'
+import { tableToCsv, tableToMarkdown } from '../src/client/blocks/charts.tsx'
 
 afterEach(() => {
   cleanup()
@@ -29,6 +30,46 @@ function renderBlock(spec: unknown, actions: Array<[string, Record<string, unkno
     </GenuiActionContext.Provider>,
   )
 }
+
+describe('v15: 导出、调色板与卡片强调色', () => {
+  it('serialises a table to Markdown and CSV (escaping included)', () => {
+    const columns = ['渠道', '备注']
+    const rows = [['自然搜索', '含,逗号'], ['付费|搜索', '含"引号"']]
+    const md = tableToMarkdown(columns, rows)
+    expect(md.split('\n')[0]).toBe('| 渠道 | 备注 |')
+    expect(md.split('\n')[1]).toBe('| --- | --- |')
+    expect(md).toContain('付费\\|搜索')
+    const csv = tableToCsv(rows)
+    expect(csv.split('\n')[0]).toBe('自然搜索,"含,逗号"')
+    expect(csv).toContain('""引号""')
+  })
+
+  it('shows the export chips only when table.export is set', () => {
+    const off = renderBlock({ items: [{ type: 'table', columns: ['A'], rows: [['1']] }] })
+    expect(off.container.querySelector('[class*="tableTools"]')).toBeNull()
+    off.unmount()
+    const on = renderBlock({ items: [{ type: 'table', export: true, columns: ['A'], rows: [['1']] }] })
+    // `[class*="tableTool"]` would also match the `.tableTools` wrapper.
+    const chips = on.container.querySelectorAll('[class*="tableTools"] button')
+    expect(chips).toHaveLength(2)
+    expect(chips[0]!.textContent).toBe('复制 Markdown')
+  })
+
+  it('accepts a hex palette and drops invalid colours', () => {
+    const spec = repairGenuiSpec({
+      items: [{ type: 'chart', palette: ['#ff8800', 'not-a-colour', '#3ecf8e'], data: [{ label: 'A', value: 1 }, { label: 'B', value: 2 }] }],
+    })!
+    expect((spec.items[0] as { palette?: string[] }).palette).toEqual(['#ff8800', '#3ecf8e'])
+  })
+
+  it('applies a card accent without changing the layout classes', () => {
+    const { container } = renderBlock({
+      items: [{ type: 'card', accent: '#f59e0b', title: '成本', items: [{ type: 'text', content: 'x' }] }],
+    })
+    const card = container.querySelector('[class*="card"]') as HTMLElement
+    expect(card.getAttribute('style')).toContain('#f59e0b')
+  })
+})
 
 describe('v14: echart preset 与 links', () => {
   it('keeps sankey/graph links through repair and drops malformed edges', () => {


### PR DESCRIPTION
三项本地能力：\n\n- `chart.palette` / `echart.palette`：显式分类色板（hex，≤12），覆盖宿主主题色；非法色值在 guard 里丢弃。\n- `card.accent`：一个色值驱动描边 + 标题 + 极淡底色，与 tone 可组合。\n- `table.export:true`：表格上方「复制 Markdown / 复制 CSV」，纯剪贴板、零往返；序列化函数导出以便测试（Markdown 转义竖线，CSV 按 RFC 4180）。\n\n文档加了「只有语义需要时才指定颜色（成本=红、收益=绿），否则跟随主题更稳」的取向说明。\n\n验证：tsc · 536 测试 · 构建 · 视觉 E2E 全绿。