### PR TITLE
style(card): accent 再收敛（描边 18% / 标题 38%）

### DIFF
--- a/src/client/GenuiBlock.module.css
+++ b/src/client/GenuiBlock.module.css
@@ -978,7 +978,7 @@
    hue toward the theme's own text colour so it stays legible on dark AND light
    surfaces (a raw accent colour on a dark card reads muddy). */
 .card[style*="--dsl-card-accent"] > .cardTitle {
-  color: color-mix(in srgb, var(--dsl-card-accent) 68%, var(--dsw-alias-label-primary));
+  color: color-mix(in srgb, var(--dsl-card-accent) 38%, var(--dsw-alias-label-primary));
 }
 
 /* Master-detail rows (table.details): a chevron in the first cell opens a

--- a/src/client/blocks/render-node.tsx
+++ b/src/client/blocks/render-node.tsx
@@ -246,7 +246,7 @@ export function renderNode(
       // clean — a blended border and the title — which also keeps charts and
       // tables inside the card colour-neutral.
       const accentStyle = node.accent === undefined ? undefined : {
-        borderColor: `color-mix(in srgb, ${node.accent} 34%, var(--dsl-g-border))`,
+        borderColor: `color-mix(in srgb, ${node.accent} 18%, var(--dsl-g-border))`,
         '--dsl-card-accent': node.accent,
       } as CSSProperties
       return (


### PR DESCRIPTION
截图反馈前先做了像素级取证：三张 accent 卡片内部颜色完全相同（srgb(35,35,35)），底色并没有被染色——看到的是彩色描边的 JPEG 色晕。\n\n真正的问题在强度：\n- 描边 34% → **18%**\n- 标题 68% → **38%**（更贴近主题文字色）\n\n这样 accent 仍是「一眼可辨的语义标记」，但不再是告警框的观感。