### PR TITLE
fix(visual): 卡片改用宿主「抬升层」，不再是一块黑

### DIFF
--- a/src/client/GenuiBlock.module.css
+++ b/src/client/GenuiBlock.module.css
@@ -111,7 +111,11 @@
 }
 
 .card {
-  background: var(--dsw-alias-bg-layer-1, var(--dsw-alias-markdown-code-block));
+  /* Elevated surface: on the dark theme layer-1 (35,35,36) sits only ~14 units
+     above the page (21,21,23) and read as "a black box". layer-2 (44,44,46) is
+     the host's own elevated surface; light theme maps all layers to one colour,
+     so this changes nothing there. */
+  background: var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, var(--dsw-alias-markdown-code-block)));
   border: 1px solid var(--dsl-g-border);
   border-radius: var(--dsl-g-radius-surface);
   padding: var(--dsl-g-gap-lg);
@@ -298,26 +302,26 @@
   background:
     radial-gradient(120% 140% at 100% 0%, color-mix(in srgb, var(--dsl-g-accent) 22%, transparent) 0%, transparent 58%),
     linear-gradient(180deg, color-mix(in srgb, var(--dsl-g-accent) 7%, transparent), transparent 70%),
-    var(--dsw-alias-bg-layer-1, transparent);
+    var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, transparent));
   overflow: hidden;
 }
 .heroSuccess {
   background:
     radial-gradient(120% 140% at 100% 0%, color-mix(in srgb, var(--dsw-alias-state-success-primary, #3ecf8e) 20%, transparent) 0%, transparent 58%),
     linear-gradient(180deg, color-mix(in srgb, var(--dsw-alias-state-success-primary, #3ecf8e) 6%, transparent), transparent 70%),
-    var(--dsw-alias-bg-layer-1, transparent);
+    var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, transparent));
 }
 .heroWarning {
   background:
     radial-gradient(120% 140% at 100% 0%, color-mix(in srgb, var(--dsw-alias-state-warn-primary, #f5b83d) 20%, transparent) 0%, transparent 58%),
     linear-gradient(180deg, color-mix(in srgb, var(--dsw-alias-state-warn-primary, #f5b83d) 6%, transparent), transparent 70%),
-    var(--dsw-alias-bg-layer-1, transparent);
+    var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, transparent));
 }
 .heroDanger {
   background:
     radial-gradient(120% 140% at 100% 0%, color-mix(in srgb, var(--dsw-alias-state-error-primary, #ff6b6b) 18%, transparent) 0%, transparent 58%),
     linear-gradient(180deg, color-mix(in srgb, var(--dsw-alias-state-error-primary, #ff6b6b) 6%, transparent), transparent 70%),
-    var(--dsw-alias-bg-layer-1, transparent);
+    var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, transparent));
 }
 .heroLabel {
   font-size: var(--dsl-g-font-meta);
@@ -391,7 +395,7 @@
   padding: 14px 16px 15px;
   border: 1px solid var(--dsl-g-border);
   border-radius: var(--dsl-g-radius-surface);
-  background: var(--dsw-alias-bg-layer-1, var(--dsw-alias-markdown-code-block, transparent));
+  background: var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, var(--dsw-alias-markdown-code-block, transparent)));
   min-width: 0;
   overflow: hidden;
 }
@@ -763,7 +767,7 @@
   border: 1px solid var(--dsl-g-border);
   font-size: var(--dsl-g-font-title);
   line-height: 1.65;
-  background: var(--dsw-alias-bg-layer-1, var(--dsw-alias-markdown-code-block));
+  background: var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, var(--dsw-alias-markdown-code-block)));
 }
 .calloutInfo { background: color-mix(in srgb, var(--dsl-g-accent) var(--dsl-g-tint), transparent); }
 .calloutSuccess { background: color-mix(in srgb, var(--dsw-alias-state-success-primary, #3ecf8e) var(--dsl-g-tint), transparent); }
@@ -1321,7 +1325,7 @@
   border: 1px solid var(--dsl-g-border);
   border-radius: var(--dsl-g-radius-surface);
   overflow: hidden;
-  background: var(--dsw-alias-bg-layer-1, transparent);
+  background: var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, transparent));
 }
 .accItem { border-bottom: 1px solid var(--dsl-g-border); }
 .accItem:last-child { border-bottom: none; }
@@ -1584,7 +1588,7 @@ button.ftNameBtn[aria-expanded] { cursor: pointer; }
   padding: var(--dsl-g-gap-lg);
   border: 1px solid var(--dsl-g-border);
   border-radius: var(--dsl-g-radius-surface);
-  background: var(--dsw-alias-bg-layer-1, transparent);
+  background: var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, transparent));
 }
 .skeletonTitle {
   display: block;

--- a/tests/genui-file-tree.spec.tsx
+++ b/tests/genui-file-tree.spec.tsx
@@ -85,6 +85,21 @@ function assertFileTreeLayout(container: HTMLElement): void {
   expect(container.textContent).toContain('README.md')
 }
 
+describe('surface elevation contract', () => {
+  it('puts cards on the elevated host layer, not the page layer', () => {
+    const css = readFileSync(join(process.cwd(), 'src/client/GenuiBlock.module.css'), 'utf8')
+    // Dark theme: page 21,21,23 → layer-1 35,35,36 (only 14 units: "a black
+    // box") → layer-2 44,44,46. Cards, stats and callouts must sit on layer-2.
+    const card = /\.card \{([^}]*)\}/.exec(css)
+    expect(card, '.card rule must exist').not.toBeNull()
+    expect(card![1]).toMatch(/background: var\(--dsw-alias-bg-layer-2/)
+    const stat = /\.stat \{([^}]*)\}/.exec(css)
+    expect(stat![1]).toMatch(/background: var\(--dsw-alias-bg-layer-2/)
+    const callout = /\.callout \{([^}]*)\}/.exec(css)
+    expect(callout![1]).toMatch(/background: var\(--dsw-alias-bg-layer-2/)
+  })
+})
+
 describe('bento card layout contract', () => {
   it('lets a card absorb the row height and centre its graphic', () => {
     const css = readFileSync(join(process.cwd(), 'src/client/GenuiBlock.module.css'), 'utf8')


### PR DESCRIPTION
反馈「卡片内部黑色的才是问题」。

**量化**：深色主题页面底色 rgb(21,21,23)，卡片用 `bg-layer-1` = rgb(35,35,36)——只差 14 级，等于页面上一块黑，没有"卡片"的浮起感。宿主自己的层级是三层：page 21 → layer-1 35 → layer-2 44 → layer-3 53。

**改法**：`card` / `stat` / `callout` / `accordion` / `hero` / 流式骨架改用 `bg-layer-2`（与页面差 23 级）；卡片内部的按钮、进度轨道仍留在 layer-1，比卡片略深，读作「嵌入控件」，层级反而更清楚。浅色主题三层同色，不受影响。

**实测**（live 深色主题，headless 强制 `colorScheme: dark`）：卡片 rgb(44,44,46) vs 页面 rgb(21,21,23)。

回归防线：CSS 契约测试断言 `card` / `stat` / `callout` 的 background 必须引用 `--dsw-alias-bg-layer-2`。
