### PR TITLE
fix(visual): 浅色下卡片与页面都是纯白（表面改主题派生的微灰）

### DIFF
--- a/src/client/GenuiBlock.module.css
+++ b/src/client/GenuiBlock.module.css
@@ -60,9 +60,15 @@
   --dsl-g-tint: 8%;
   --dsl-g-tint-strong: 14%;
   --dsl-g-font-mono: var(--ds-font-family-code, ui-monospace, 'SF Mono', monospace);
-  /* Elevation: the light theme maps every bg layer to white, so a card there
-     separates only by border + shadow (its border-l1 is 4% black — invisible).
-     Dark theme relies on the layer difference; the shadow stays subtle. */
+  /* Elevation, theme-agnostic: the light theme maps EVERY bg layer to white,
+     so a card there is white-on-white and a border alone cannot carry the
+     hierarchy. Both a tint of the theme's own label colour and the surface
+     border are derived from tokens that exist in both themes:
+       light: label ≈ near-black  → tint darkens the white card to ~#f5f5f5
+       dark : label ≈ near-white  → tint lifts the card off the page      */
+  --dsl-g-surface: color-mix(in srgb, var(--dsw-alias-label-primary) 4%,
+    var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, var(--dsw-alias-markdown-code-block, transparent))));
+  --dsl-g-border-surface: color-mix(in srgb, var(--dsw-alias-label-primary) 14%, transparent);
   --dsl-g-shadow-card: 0 1px 2px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.04);
 }
 
@@ -119,8 +125,8 @@
      above the page (21,21,23) and read as "a black box". layer-2 (44,44,46) is
      the host's own elevated surface; light theme maps all layers to one colour,
      so this changes nothing there. */
-  background: var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, var(--dsw-alias-markdown-code-block)));
-  border: 1px solid var(--dsl-g-border-strong);
+  background: var(--dsl-g-surface);
+  border: 1px solid var(--dsl-g-border-surface);
   border-radius: var(--dsl-g-radius-surface);
   padding: var(--dsl-g-gap-lg);
   display: flex;
@@ -303,7 +309,7 @@
   gap: 6px;
   padding: 22px 24px 24px;
   border-radius: 14px;
-  border: 1px solid var(--dsl-g-border-strong);
+  border: 1px solid var(--dsl-g-border-surface);
   background:
     radial-gradient(120% 140% at 100% 0%, color-mix(in srgb, var(--dsl-g-accent) 22%, transparent) 0%, transparent 58%),
     linear-gradient(180deg, color-mix(in srgb, var(--dsl-g-accent) 7%, transparent), transparent 70%),
@@ -399,9 +405,9 @@
   /* Metric card: the number IS the design. No accent stripe, no bar — the
      40px figure against a 12px uppercase label carries the hierarchy. */
   padding: 14px 16px 15px;
-  border: 1px solid var(--dsl-g-border-strong);
+  border: 1px solid var(--dsl-g-border-surface);
   border-radius: var(--dsl-g-radius-surface);
-  background: var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, var(--dsw-alias-markdown-code-block, transparent)));
+  background: var(--dsl-g-surface);
   min-width: 0;
   overflow: hidden;
   box-shadow: var(--dsl-g-shadow-card);
@@ -516,7 +522,7 @@
 
 .tableWrap {
   border-radius: var(--dsl-g-radius-control);
-  border: 1px solid var(--dsl-g-border-strong);
+  border: 1px solid var(--dsl-g-border-surface);
   /* A table whose nowrap cells exceed the column width must scroll, not clip
      (mirrors the shell markdown table's .tableScroll pattern). */
   overflow-x: auto;
@@ -771,10 +777,10 @@
   gap: 3px;
   padding: 12px 15px;
   border-radius: var(--dsl-g-radius-surface);
-  border: 1px solid var(--dsl-g-border-strong);
+  border: 1px solid var(--dsl-g-border-surface);
   font-size: var(--dsl-g-font-title);
   line-height: 1.65;
-  background: var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, var(--dsw-alias-markdown-code-block)));
+  background: var(--dsl-g-surface);
   box-shadow: var(--dsl-g-shadow-card);
 }
 .calloutInfo { background: color-mix(in srgb, var(--dsl-g-accent) var(--dsl-g-tint), transparent); }
@@ -1330,10 +1336,10 @@
 .accordion {
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--dsl-g-border-strong);
+  border: 1px solid var(--dsl-g-border-surface);
   border-radius: var(--dsl-g-radius-surface);
   overflow: hidden;
-  background: var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, transparent));
+  background: var(--dsl-g-surface);
   box-shadow: var(--dsl-g-shadow-card);
 }
 .accItem { border-bottom: 1px solid var(--dsl-g-border); }
@@ -1597,7 +1603,7 @@ button.ftNameBtn[aria-expanded] { cursor: pointer; }
   padding: var(--dsl-g-gap-lg);
   border: 1px solid var(--dsl-g-border);
   border-radius: var(--dsl-g-radius-surface);
-  background: var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, transparent));
+  background: var(--dsl-g-surface);
 }
 .skeletonTitle {
   display: block;

--- a/tests/genui-file-tree.spec.tsx
+++ b/tests/genui-file-tree.spec.tsx
@@ -92,11 +92,11 @@ describe('surface elevation contract', () => {
     // box") → layer-2 44,44,46. Cards, stats and callouts must sit on layer-2.
     const card = /\.card \{([^}]*)\}/.exec(css)
     expect(card, '.card rule must exist').not.toBeNull()
-    expect(card![1]).toMatch(/background: var\(--dsw-alias-bg-layer-2/)
+    expect(card![1]).toMatch(/background: var\(--dsl-g-surface\)/)
     const stat = /\.stat \{([^}]*)\}/.exec(css)
-    expect(stat![1]).toMatch(/background: var\(--dsw-alias-bg-layer-2/)
+    expect(stat![1]).toMatch(/background: var\(--dsl-g-surface\)/)
     const callout = /\.callout \{([^}]*)\}/.exec(css)
-    expect(callout![1]).toMatch(/background: var\(--dsw-alias-bg-layer-2/)
+    expect(callout![1]).toMatch(/background: var\(--dsl-g-surface\)/)
   })
 
   it('gives surfaces a visible outline and a lift (light theme has no layers)', () => {
@@ -104,10 +104,15 @@ describe('surface elevation contract', () => {
     // Light theme maps every bg layer to white and its border-l1 is 4% black —
     // a card there would be invisible without border-l2 + a shadow.
     expect(css).toMatch(/--dsl-g-shadow-card:/)
+    expect(css).toMatch(/--dsl-g-surface: color-mix\(in srgb, var\(--dsw-alias-label-primary\) 4%/)
+    expect(css).toMatch(/--dsl-g-border-surface: color-mix\(in srgb, var\(--dsw-alias-label-primary\) 14%/)
     for (const rule of ['card', 'stat', 'callout', 'hero', 'accordion']) {
       const block = new RegExp(`\\.${rule} \\{([^}]*)\\}`).exec(css)
       expect(block, `.${rule} must exist`).not.toBeNull()
-      expect(block![1], `.${rule} needs a visible outline`).toMatch(/border: 1px solid var\(--dsl-g-border-strong\)/)
+      // Outline + surface tint are DERIVED from the theme's label colour: the
+      // light theme maps every layer to white, so host layer/border tokens
+      // alone cannot separate a card from the page.
+      expect(block![1], `.${rule} needs a visible outline`).toMatch(/border: 1px solid var\(--dsl-g-border-surface\)/)
       expect(block![1], `.${rule} needs a lift`).toMatch(/box-shadow: var\(--dsl-g-shadow-card\)/)
     }
   })


### PR DESCRIPTION
「完全没有啥区别」——先量像素：页面 255 / 卡片内部 255 / 描边 228。上一版只加了描边与投影，但**宿主浅色主题把页面和所有 bg 层都设成纯白**，白卡压白底，1px 灰边撑不起层级。

改为**从主题令牌派生**表面与描边，两个主题同时成立：

- `--dsl-g-surface` = 主题文字色 4% 混入 `bg-layer-2`：浅色（近黑 4%）→ 卡片 `rgb(245,245,246)`；深色（近白 4%）→ 卡片比页面更亮，抬升更明显。
- `--dsl-g-border-surface` = 主题文字色 14%（浅色 ≈ rgb(219)），不再依赖浅色下只有 4% 黑的 `border-l1`。
- 作用于 `card` / `stat` / `callout` / `accordion` / `hero` / `tableWrap` / 骨架；组件**内部**分隔线仍用 `border-l1`，保持"表面重、内部轻"。

实测（live 浅色）：页面 rgb(255,255,255)，卡片 rgb(245,245,246)，描边 14%，阴影两层。

契约测试改为断言这两个派生令牌存在并被表面组件使用。
