### PR TITLE
fix(visual): 表面 tint 4%→10%、描边 14%→24%（跨过感知阈值）

### DIFF
--- a/src/client/GenuiBlock.module.css
+++ b/src/client/GenuiBlock.module.css
@@ -66,10 +66,13 @@
      border are derived from tokens that exist in both themes:
        light: label ≈ near-black  → tint darkens the white card to ~#f5f5f5
        dark : label ≈ near-white  → tint lifts the card off the page      */
-  --dsl-g-surface: color-mix(in srgb, var(--dsw-alias-label-primary) 4%,
+  /* 4% / 14% measured as 255→246 and read as "no difference" in review: the
+     tint now sits clearly above the perception floor. Light: page 255 → card
+     ~232, border ~190. Dark: page 21 → card ~62 (an unmistakable elevation). */
+  --dsl-g-surface: color-mix(in srgb, var(--dsw-alias-label-primary) 10%,
     var(--dsw-alias-bg-layer-2, var(--dsw-alias-bg-layer-1, var(--dsw-alias-markdown-code-block, transparent))));
-  --dsl-g-border-surface: color-mix(in srgb, var(--dsw-alias-label-primary) 14%, transparent);
-  --dsl-g-shadow-card: 0 1px 2px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.04);
+  --dsl-g-border-surface: color-mix(in srgb, var(--dsw-alias-label-primary) 24%, transparent);
+  --dsl-g-shadow-card: 0 1px 2px rgba(0, 0, 0, 0.06), 0 6px 16px rgba(0, 0, 0, 0.07);
 }
 
 .block {

--- a/tests/genui-file-tree.spec.tsx
+++ b/tests/genui-file-tree.spec.tsx
@@ -104,8 +104,8 @@ describe('surface elevation contract', () => {
     // Light theme maps every bg layer to white and its border-l1 is 4% black —
     // a card there would be invisible without border-l2 + a shadow.
     expect(css).toMatch(/--dsl-g-shadow-card:/)
-    expect(css).toMatch(/--dsl-g-surface: color-mix\(in srgb, var\(--dsw-alias-label-primary\) 4%/)
-    expect(css).toMatch(/--dsl-g-border-surface: color-mix\(in srgb, var\(--dsw-alias-label-primary\) 14%/)
+    expect(css).toMatch(/--dsl-g-surface: color-mix\(in srgb, var\(--dsw-alias-label-primary\) 10%/)
+    expect(css).toMatch(/--dsl-g-border-surface: color-mix\(in srgb, var\(--dsw-alias-label-primary\) 24%/)
     for (const rule of ['card', 'stat', 'callout', 'hero', 'accordion']) {
       const block = new RegExp(`\\.${rule} \\{([^}]*)\\}`).exec(css)
       expect(block, `.${rule} must exist`).not.toBeNull()


### PR DESCRIPTION
反馈「这他妈哪看的出区别」——先量，不争：卡片 246 / 页面 255 / 描边 206。样式**生效了**，但 3.5% 的填充差在压缩截图和亮屏上读不出来，等于没改。

- 表面 tint **4% → 10%**：浅色 255 → 卡片 `rgb(231)`；深色 21 → 卡片 `rgb(63)`。两个主题都跨过感知阈值。
- 描边 **14% → 24%**：浅色约 `rgb(196)`。
- 阴影 `0.05/0.04 → 0.06/0.07`。

实测（live 浅色）：页面 `rgb(255,255,255)`，卡片 `rgb(231,231,232)`，描边 `rgba(15,17,21,0.24)`。

教训记一笔：前几轮我都在 4% 附近打转，属于"可测量但不可见"的区间；这次直接跳到能一眼认出的强度，宁可先过一点再回调。
