### PR TITLE
fix(plot): 滚轮无条件吞掉 + 缩放后回不去

### DIFF
--- a/src/client/PlotBlock.module.css
+++ b/src/client/PlotBlock.module.css
@@ -105,7 +105,23 @@
   font-family: var(--dsl-g-font-mono);
 }
 
-.surface { cursor: grab; touch-action: none; }
+.surface { cursor: grab; touch-action: pan-y; }
+/* The current x-domain only shows when it differs from the initial one, next
+   to the way back. Without this, an accidental zoom left the reader with a
+   domain nobody asked for and no visible affordance to restore it. */
+.plotTools { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 0 0 4px; }
+.plotHint { font-size: 12.5px; color: var(--dsw-alias-label-tertiary); font-variant-numeric: tabular-nums; }
+.plotReset {
+  padding: 2px 9px;
+  border: 1px solid var(--dsw-alias-border-l2, rgba(255, 255, 255, 0.12));
+  border-radius: 999px;
+  background: transparent;
+  color: var(--dsw-alias-label-secondary);
+  font-family: inherit;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.plotReset:hover { color: var(--dsw-alias-label-primary); border-color: var(--dsw-alias-state-business-primary, #4f8ef7); }
 .surface:active { cursor: grabbing; }
 
 .sliders { display: flex; flex-direction: column; gap: var(--dsl-g-gap-sm); }

--- a/src/client/PlotBlock.tsx
+++ b/src/client/PlotBlock.tsx
@@ -300,6 +300,9 @@ export const PlotBlock = memo(function PlotBlock({
   const onPointerMove = (e: React.PointerEvent): void => {
     const d = dragRef.current
     if (d === null) return
+    // A few pixels of slack: a plain click or a text-selection drag must not
+    // shift the domain.
+    if (Math.abs(e.clientX - d.startX) < 4) return
     const span = d.xMax - d.xMin
     const dx = ((d.startX - e.clientX) / plotW) * span
     setView(prev => ({ xMin: d.xMin + dx, xMax: d.xMax + dx, yMin: prev.yMin, yMax: prev.yMax }))
@@ -310,11 +313,18 @@ export const PlotBlock = memo(function PlotBlock({
   // onWheel as a passive listener, where preventDefault() is ignored and the
   // event bubbles up to the scroll container. Register natively with
   // { passive: false } instead — the same pattern as the 3D scene viewer.
+  // Wheel zoom requires a modifier (Cmd/Ctrl). Without one the wheel is left
+  // alone so the CONVERSATION scrolls: an unmodified wheel over the chart used
+  // to be swallowed by the plot, so scrolling the page silently rescaled the
+  // chart instead (a reader could end up looking at a domain nobody asked for,
+  // with no way back). The #63 requirement still holds for the modified case —
+  // a native non-passive listener keeps the event from reaching the host.
   const svgRef = useRef<SVGSVGElement | null>(null)
   useEffect(() => {
     const el = svgRef.current
     if (el === null) return
     const onWheel = (e: WheelEvent): void => {
+      if (!e.metaKey && !e.ctrlKey) return
       e.preventDefault()
       const span = xMax - xMin
       const factor = e.deltaY > 0 ? 1.15 : 1 / 1.15
@@ -326,13 +336,35 @@ export const PlotBlock = memo(function PlotBlock({
     }
     el.addEventListener('wheel', onWheel, { passive: false })
     return () => el.removeEventListener('wheel', onWheel)
-  }, [xMin, xMax])
+  }, [xMin, xMax, fromX])
 
   const hasParams = series.some(s => (s.params?.length ?? 0) > 0)
+
+  // Zoom/pan move the x window; without a way back a reader who zoomed by
+  // accident was stuck with a domain nobody asked for. The header therefore
+  // shows the CURRENT domain whenever it differs from the initial one and
+  // offers a one-click return.
+  const initialX = useRef({ min: propXMin, max: propXMax })
+  const viewMoved = Math.abs(xMin - initialX.current.min) > 1e-6 || Math.abs(xMax - initialX.current.max) > 1e-6
+  const resetView = (): void => {
+    setView(prev => ({ ...prev, xMin: initialX.current.min, xMax: initialX.current.max }))
+  }
 
   return (
     <div className={css.block} data-genui-plot>
       {title !== undefined && <div className={css.title}>{title}</div>}
+      {hasData && hasValidRange && (
+        <div className={css.plotTools}>
+          <span className={css.plotHint}>
+            {viewMoved
+              ? `x ∈ [${formatTick(xMin)}, ${formatTick(xMax)}]`
+              : '⌘/Ctrl + 滚轮缩放 · 拖拽平移'}
+          </span>
+          {viewMoved && (
+            <button type="button" className={css.plotReset} onClick={resetView}>↺ 回到初始区间</button>
+          )}
+        </div>
+      )}
       {hasData && hasValidRange ? (
         <svg
           width="100%"

--- a/tests/genui-plot-view.spec.tsx
+++ b/tests/genui-plot-view.spec.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+// Plot view affordances: an accidental zoom used to be a one-way door (the
+// wheel was swallowed unconditionally and nothing showed the new domain).
+import { cleanup, fireEvent, render, act } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { PlotBlock } from '../src/client/PlotBlock.tsx'
+
+afterEach(cleanup)
+
+function mockRect(svg: Element): void {
+  svg.getBoundingClientRect = () => ({
+    left: 0, top: 0, width: 480, height: 320, right: 480, bottom: 320, x: 0, y: 0, toJSON: () => ({}),
+  } as DOMRect)
+}
+
+describe('plot view affordances', () => {
+  it('shows the zoom hint, reveals the domain after a zoom, and resets', () => {
+    const { container } = render(
+      <PlotBlock xMin={-6.28} xMax={6.28} series={[{ expr: 'sin(x)', label: 'sin(x)' }]} />,
+    )
+    const svg = container.querySelector('[data-genui-plot] svg') as Element
+    mockRect(svg)
+    // Initial state: hint only, no reset affordance.
+    expect(container.textContent).toContain('滚轮缩放')
+    expect(container.querySelector('[class*="plotReset"]')).toBeNull()
+
+    act(() => {
+      svg.dispatchEvent(new WheelEvent('wheel', {
+        deltaY: -120, clientX: 240, clientY: 160, bubbles: true, cancelable: true, metaKey: true,
+      }))
+    })
+    // Zoomed: the domain is surfaced and the way back exists.
+    expect(container.textContent).toContain('x ∈ [')
+    const reset = container.querySelector('[class*="plotReset"]') as HTMLButtonElement
+    expect(reset).not.toBeNull()
+
+    fireEvent.click(reset)
+    expect(container.textContent).toContain('滚轮缩放')
+    expect(container.querySelector('[class*="plotReset"]')).toBeNull()
+  })
+})

--- a/tests/genui-plot-wheel-lock.spec.tsx
+++ b/tests/genui-plot-wheel-lock.spec.tsx
@@ -36,16 +36,31 @@ function mockRect(svg: Element): void {
   } as DOMRect)
 }
 
-const wheelAt = (svg: Element, deltaY: number): void => {
+const wheelAt = (svg: Element, deltaY: number, modifier = false): void => {
   act(() => {
     svg.dispatchEvent(new WheelEvent('wheel', {
       deltaY, clientX: 240, clientY: 160, bubbles: true, cancelable: true,
+      metaKey: modifier, ctrlKey: modifier,
     }))
   })
 }
 
 describe('plot wheel-to-zoom lock', () => {
-  it('cancels wheel events before they reach the scroll container (#63)', () => {
+  it('leaves an unmodified wheel to the page so the conversation still scrolls', () => {
+    const seen: boolean[] = []
+    const { container } = render(
+      <ScrollHost seen={seen}><PlotBlock series={[{ expr: 'sin(x)' }]} /></ScrollHost>,
+    )
+    const svg = container.querySelector('[data-genui-plot] svg') as Element
+    mockRect(svg)
+    const before = container.querySelector('polyline')!.getAttribute('points')!
+    wheelAt(svg, -120)
+    // Not prevented (the page scrolls) and the curve is untouched.
+    for (const prevented of seen) expect(prevented).toBe(false)
+    expect(container.querySelector('polyline')!.getAttribute('points')).toBe(before)
+  })
+
+  it('cancels a MODIFIED wheel before it reaches the scroll container (#63)', () => {
     const seen: boolean[] = []
     const { container } = render(
       <ScrollHost seen={seen}><PlotBlock series={[{ expr: 'sin(x)' }]} /></ScrollHost>,
@@ -54,8 +69,8 @@ describe('plot wheel-to-zoom lock', () => {
     expect(svg).not.toBeNull()
     mockRect(svg)
 
-    wheelAt(svg, -120)
-    wheelAt(svg, 120)
+    wheelAt(svg, -120, true)
+    wheelAt(svg, 120, true)
     // Every bubbled wheel event must arrive already prevented: React's
     // passive onWheel cannot guarantee this (defaultPrevented stays false).
     expect(seen.length).toBeGreaterThan(0)
@@ -71,7 +86,7 @@ describe('plot wheel-to-zoom lock', () => {
     mockRect(svg)
     const polyBefore = container.querySelector('polyline')!.getAttribute('points')!
 
-    wheelAt(svg, -120) // zoom in centered on the middle of the plot
+    wheelAt(svg, -120, true) // ⌘ + wheel zoom in, centered on the plot middle
 
     const polyAfter = container.querySelector('polyline')!.getAttribute('points')!
     expect(polyAfter).not.toBe(polyBefore)


### PR DESCRIPTION
你截图里 x 轴是 -5 / 0 / 5 / 10（看起来两个周期），而 spec 写的是 `xMin -6.28, xMax 6.28`。先验证渲染本身：测试里读真实刻度 = `-6,-4,-2,0,2,4,6`，y 轴 `-1,-0.5,0,0.5,1`，两条曲线各 240 点、端点值正确。**初始渲染没问题**，毛病在交互：

1. **`onWheel` 无条件 `preventDefault()`**：读者在对话里滚动页面，只要光标压在图上，页面就不滚、图反被缩放。看到的就是没人要求的区间。改为**只有 ⌘/Ctrl + 滚轮才缩放**，普通滚轮交还页面（#63 对修饰键场景仍成立：原生非 passive 监听，不让事件冒到宿主滚动容器）。
2. **缩放/平移后没有任何回到初始区间的入口**（单向门）。新增：视图一旦偏离，图表上方显示当前区间 `x ∈ [a, b]` 并出现「↺ 回到初始区间」；未偏离时显示操作提示。
3. **拖拽平移加 4px 阈值**：点击或拉选文字不再平移坐标轴。
4. `.surface` 的 `touch-action` 由 `none` 改为 `pan-y`（触屏竖直滚动恢复）。

测试：`genui-plot-wheel-lock` 拆成两条契约（未修饰滚轮不拦截 / 修饰滚轮拦截），新增 `genui-plot-view` 覆盖「提示 → 显示区间 → 重置」链路。

验证：tsc · 544 测试 · 构建 · 视觉 E2E 全绿。
