### PR TITLE
fix(design): ⑤⑥⑦ 设计问题（mermaid 主题 / steps 标记 / quiz 标记 / 表单可见性 / 媒体塌陷）

### DIFF
--- a/scripts/e2e-visual.mts
+++ b/scripts/e2e-visual.mts
@@ -245,6 +245,26 @@ try {
   await page.screenshot({ path: join(OUT_DIR, 'gallery.png'), fullPage: true })
   log(`✓ 截图 gallery.png`)
 
+  // Per-component crops: the gallery is far taller than a viewport, so a
+  // single full-page shot is useless for reviewing one component's design.
+  const parts: Array<[string, string]> = [
+    ['steps', '[class*="steps"]'],
+    ['timeline', '[class*="timeline"]'],
+    ['mermaid', '[data-genui] svg[id^="mermaid"], [class*="mermaid"] svg'],
+    ['quiz', '[class*="quiz"]'],
+    ['media', '[class*="media"]'],
+    ['kv', '[class*="kvRow"]'],
+    ['controls', '[class*="input"], [class*="select"], [class*="textarea"]'],
+  ]
+  for (const [name, selector] of parts) {
+    const el = await page.$(selector)
+    if (el === null) continue
+    await el.scrollIntoViewIfNeeded()
+    await page.waitForTimeout(250)
+    await el.screenshot({ path: join(OUT_DIR, `part-${name}.png`) }).catch(() => {})
+  }
+  log(`✓ 组件逐个截图：${parts.map(p => p[0]).join(' / ')}`)
+
   // ── 流式骨架验证 ─────────────────────────────────────────────────────────
   // 半截 JSON 的 dsh-ui 围栏：不显示裸 JSON，而是骨架；settle 后若仍解析不了
   // 必须把原始代码块还回来（不能永久藏起来）。

--- a/src/client/GenuiBlock.module.css
+++ b/src/client/GenuiBlock.module.css
@@ -98,6 +98,10 @@ body[data-ds-dark-theme] .panel {
   /* Numbers line up wherever they appear (stats, tables, progress, legends). */
   font-variant-numeric: tabular-nums;
 }
+/* Content-box padding made a <select> and an <input> with the same
+   width:100% measure 365 vs 391px. One reset inside our subtree. */
+.block *, .block *::before, .block *::after,
+.panel *, .panel *::before, .panel *::after { box-sizing: border-box; }
 
 .banner {
   /* Hierarchy through type, not decoration: 22px/800 with generous space
@@ -257,8 +261,8 @@ body[data-ds-dark-theme] .panel {
 .field > span { font-size: var(--dsl-g-font-meta); color: var(--dsw-alias-label-tertiary); }
 
 .input, .select {
-  background: var(--dsw-alias-bg-base, #17171a);
-  border: 1px solid var(--dsl-g-border);
+  background: var(--dsl-g-surface);
+  border: 1px solid var(--dsl-g-border-surface);
   border-radius: var(--dsl-g-radius-control);
   color: var(--dsw-alias-label-primary);
   padding: 8px 12px;
@@ -310,12 +314,15 @@ body[data-ds-dark-theme] .panel {
   display: flex;
   flex-direction: column;
   gap: var(--dsl-g-gap-sm);
-  background: var(--dsw-alias-bg-layer-1, var(--dsw-alias-markdown-code-block));
-  border: 1px solid var(--dsl-g-border);
+  background: var(--dsl-g-surface);
+  border: 1px solid var(--dsl-g-border-surface);
   border-radius: var(--dsl-g-radius-surface);
 }
 .mediaLabel { font-size: var(--dsl-g-font-title); font-weight: 600; color: var(--dsw-alias-label-primary); }
-.mediaPlayer { display: block; width: 100%; min-width: 0; }
+.mediaPlayer { display: block; width: 100%; min-width: 0; border-radius: var(--dsl-g-radius-control); }
+/* Reserve the box before the bytes arrive: without an intrinsic ratio an
+   unloaded <img> collapses to 0px and the card looks broken. */
+img.mediaPlayer { aspect-ratio: 16 / 9; object-fit: cover; background: var(--dsl-g-surface); }
 .videoPlayer { max-height: min(70vh, 720px); background: #000; object-fit: contain; }
 .mediaError { font-size: var(--dsl-g-font-title); color: var(--dsw-alias-state-error-primary, #f25a5a); }
 
@@ -858,8 +865,8 @@ body[data-ds-dark-theme] .panel {
   font-size: var(--dsl-g-font-meta);
   font-weight: 700;
   flex-shrink: 0;
-  background: var(--dsw-alias-bg-layer-1);
-  border: 1px solid var(--dsl-g-border);
+  background: var(--dsl-g-surface);
+  border: 1px solid var(--dsl-g-border-surface);
   color: var(--dsw-alias-label-secondary);
   z-index: 1;
 }
@@ -1336,8 +1343,8 @@ body[data-ds-dark-theme] .panel {
 
 .textarea {
   width: 100%;
-  background: var(--dsw-alias-bg-base, #17171a);
-  border: 1px solid var(--dsl-g-border);
+  background: var(--dsl-g-surface);
+  border: 1px solid var(--dsl-g-border-surface);
   border-radius: var(--dsl-g-radius-control);
   color: var(--dsw-alias-label-primary);
   padding: var(--dsl-g-gap-sm) 12px;
@@ -1808,7 +1815,16 @@ button.ftNameBtn[aria-expanded] { cursor: pointer; }
   color: var(--dsw-alias-state-success-primary, #3ecf8e);
   line-height: 1.5;
 }
-.quizMarker { width: 16px; text-align: center; font-weight: 700; }
+.quizMarker {
+  display: inline-block;
+  width: 14px;
+  text-align: center;
+  font-weight: 700;
+  color: var(--dsw-alias-label-tertiary);
+  flex-shrink: 0;
+}
+.quizOptCorrect .quizMarker { color: var(--dsw-alias-state-success-primary, #3ecf8e); }
+.quizOptWrong .quizMarker { color: var(--dsw-alias-state-error-primary, #ff6b6b); }
 .quizResult { display: flex; flex-direction: column; gap: var(--dsl-g-gap-sm); }
 .quizCorrectMsg { font-size: var(--dsl-g-font-title); font-weight: 600; color: var(--dsw-alias-state-success-primary, #3ecf8e); }
 .quizWrongMsg { font-size: var(--dsl-g-font-title); font-weight: 600; color: var(--dsw-alias-state-error-primary, #ff6b6b); }

--- a/src/client/blocks/advanced.tsx
+++ b/src/client/blocks/advanced.tsx
@@ -471,7 +471,11 @@ export const QuizNode = memo(function QuizNode({ node, onAction }: {
                 }
               }}
             >
-              <span className={css.quizMarker}>{answered && (opt.correct === true ? '✓' : isChosen ? '✗' : '')}</span>
+              {/* Before answering: a radio affordance so the row reads as a
+                  choice. After: ✓ on the right answer, ✗ on a wrong pick. */}
+              <span className={css.quizMarker}>
+                {answered ? (opt.correct === true ? '✓' : isChosen ? '✗' : '') : isChosen ? '●' : '○'}
+              </span>
               {opt.label}
             </button>
           )

--- a/src/client/mermaid-core.ts
+++ b/src/client/mermaid-core.ts
@@ -25,15 +25,52 @@ let renderSeq = 0
 function loadMermaid(): Promise<typeof import('mermaid')> {
   mermaidPromise ??= import('mermaid').then(async m => {
     const api = m.default
-    // Follow the host theme: boot-theme sets colorScheme on <html>; a
-    // dark-forced diagram on a light chat looked broken.
-    const dark = typeof document !== 'undefined'
-      && document.documentElement.style.colorScheme === 'dark'
+    // Theme the diagram from the HOST tokens instead of a built-in mermaid
+    // palette: the stock themes render grey boxes with sharp corners, dark
+    // strokes and their own font, which sat next to our components as a
+    // visibly foreign object. `base` + themeVariables is the supported way to
+    // drive every colour (the dark/light branch is gone with it).
+    const token = (name: string, fallback: string): string => {
+      if (typeof document === 'undefined') return fallback
+      const value = getComputedStyle(document.body).getPropertyValue(name).trim()
+      return value === '' ? fallback : value
+    }
     api.initialize({
       startOnLoad: false,
       // Strict default: mermaid escapes/sanitizes; we never enable htmlLabels.
       securityLevel: 'strict',
-      theme: dark ? 'dark' : 'neutral',
+      theme: 'base',
+      themeVariables: {
+        background: 'transparent',
+        fontFamily: 'inherit',
+        fontSize: '13px',
+        primaryColor: token('--dsw-alias-bg-layer-2', '#2c2c2e'),
+        primaryTextColor: token('--dsw-alias-label-primary', '#e6e6e6'),
+        primaryBorderColor: token('--dsw-alias-border-l2', 'rgba(255,255,255,0.12)'),
+        secondaryColor: token('--dsw-alias-bg-layer-2', '#2c2c2e'),
+        secondaryTextColor: token('--dsw-alias-label-primary', '#e6e6e6'),
+        secondaryBorderColor: token('--dsw-alias-border-l2', 'rgba(255,255,255,0.12)'),
+        tertiaryColor: token('--dsw-alias-bg-layer-2', '#2c2c2e'),
+        tertiaryTextColor: token('--dsw-alias-label-primary', '#e6e6e6'),
+        tertiaryBorderColor: token('--dsw-alias-border-l2', 'rgba(255,255,255,0.12)'),
+        mainBkg: token('--dsw-alias-bg-layer-2', '#2c2c2e'),
+        nodeBorder: token('--dsw-alias-border-l2', 'rgba(255,255,255,0.12)'),
+        nodeTextColor: token('--dsw-alias-label-primary', '#e6e6e6'),
+        lineColor: token('--dsw-alias-label-tertiary', '#8a8a92'),
+        textColor: token('--dsw-alias-label-primary', '#e6e6e6'),
+        edgeLabelBackground: 'transparent',
+        clusterBkg: 'transparent',
+        clusterBorder: token('--dsw-alias-border-l2', 'rgba(255,255,255,0.12)'),
+        titleColor: token('--dsw-alias-label-primary', '#e6e6e6'),
+      },
+      // Sharp corners and heavy strokes were the loudest mismatch; the radius
+      // is set here because mermaid emits plain <rect> geometry.
+      themeCSS: [
+        '.node rect, .node polygon, .node circle, .node ellipse { rx: 8px; ry: 8px; stroke-width: 1px; }',
+        '.cluster rect { rx: 10px; ry: 10px; }',
+        '.edgePath .path { stroke-width: 1.4px; }',
+        '.label { color: inherit; }',
+      ].join(' '),
       // Fail loudly: with suppressErrorRendering false (the default) mermaid
       // renders an "error" diagram on parse/draw failure — the caller then
       // receives a normal-looking SVG whose text is the raw engine error

--- a/tests/genui-file-tree.spec.tsx
+++ b/tests/genui-file-tree.spec.tsx
@@ -85,6 +85,50 @@ function assertFileTreeLayout(container: HTMLElement): void {
   expect(container.textContent).toContain('README.md')
 }
 
+describe('component design contract (measured defects)', () => {
+  const css = () => readFileSync(join(process.cwd(), 'src/client/GenuiBlock.module.css'), 'utf8')
+
+  it('keeps every control and marker visible in light mode', () => {
+    const c = css()
+    // Measured: the pending step marker had a 4%-black border and a page-coloured
+    // fill (invisible ring); inputs sat on the page colour with the same 4% border.
+    const step = /\.stepMarker \{([^}]*)\}/.exec(c)!
+    expect(step[1]).toMatch(/background: var\(--dsl-g-surface\)/)
+    expect(step[1]).toMatch(/border: 1px solid var\(--dsl-g-border-surface\)/)
+    for (const rule of ['\.input, \.select', '\.textarea']) {
+      const block = new RegExp(`${rule} \\{([^}]*)\\}`).exec(c)!
+      expect(block[1]).toMatch(/background: var\(--dsl-g-surface\)/)
+      expect(block[1]).toMatch(/border: 1px solid var\(--dsl-g-border-surface\)/)
+    }
+  })
+
+  it('reserves the media box before the bytes arrive', () => {
+    // Measured 213x0: an unloaded <img> collapsed and the card looked broken.
+    expect(css()).toMatch(/img\.mediaPlayer \{[^}]*aspect-ratio: 16 \/ 9/)
+    expect(css()).toMatch(/img\.mediaPlayer \{[^}]*object-fit: cover/)
+  })
+
+  it('gives quiz options a selection affordance from the start', () => {
+    // Measured 16x0 (empty inline span): the options read as plain grey bars.
+    const marker = /\.quizMarker \{([^}]*)\}/.exec(css())!
+    expect(marker[1]).toMatch(/display: inline-block/)
+    expect(marker[1]).toMatch(/width: 14px/)
+  })
+
+  it('resets box-sizing inside the block (select vs input grew 26px apart)', () => {
+    expect(css()).toMatch(/\.block \*, \.block \*::before, \.block \*::after,[\s\S]{0,120}?box-sizing: border-box/)
+  })
+
+  it('themes mermaid from host tokens, not a stock palette', () => {
+    const core = readFileSync(join(process.cwd(), 'src/client/mermaid-core.ts'), 'utf8')
+    // Stock themes drew grey boxes with sharp corners next to rounded host UI.
+    expect(core).toMatch(/theme: 'base'/)
+    expect(core).toMatch(/themeVariables: \{/)
+    expect(core).toMatch(/--dsw-alias-bg-layer-2/)
+    expect(core).toMatch(/rx: 8px; ry: 8px/)
+  })
+})
+
 describe('surface elevation contract', () => {
   it('puts cards on the elevated host layer, not the page layer', () => {
     const css = readFileSync(join(process.cwd(), 'src/client/GenuiBlock.module.css'), 'utf8')


### PR DESCRIPTION
「1-4 蛮好的，后面的需要改善优化」——这一轮只改设计，不改内容，每条都有测量依据（live 页面读计算样式 + 逐组件截图）。

| # | 实测到的缺陷 | 改法 |
|---|---|---|
| 1 | **mermaid 用自带主题**：灰底黑字、直角、字体不匹配，摆在圆角宿主 UI 旁像外来物 | `theme:'base'` + `themeVariables` 全取自宿主令牌；`themeCSS` 给节点 8px 圆角、连线 1.4px；去掉 dark/light 分支 |
| 2 | **steps 待办标记没有圆圈**（border-l1 = 浅色 4% 黑 + 页面色底） | 改用 `--dsl-g-border-surface` + `--dsl-g-surface` |
| 3 | **quiz 选项无选择标识**（标记 span 实测 16×0） | 始终渲染 ○ / 选中 ● / 判卷后 ✓✗，标记固定宽度与配色 |
| 4 | **表单控件浅色下几乎不可见**；input 391 vs select **365** | 控件改 surface + border-surface；`.block` 子树加 `box-sizing: border-box` 重置（消掉 content-box 的 26px 漂移） |
| 5 | **媒体图片高度塌成 0**（213×0，未加载时无固有比例） | `img.mediaPlayer` 加 `aspect-ratio:16/9` + `object-fit:cover`，统一圆角 |

顺带给 E2E 加了「按组件逐个截图」：画廊比视口高太多，整页截图对评审单个组件没用。

验证：tsc · 549 测试（新增 5 条设计契约）· 构建 · 视觉 E2E 全绿。逐组件截图确认 mermaid 圆角/宿主色、steps 圆圈、quiz ○ 标记、输入框可见边框均已生效。
