### PR TITLE
test(css): 宿主隔离契约（禁止裸元素选择器与 :global）

### DIFF
--- a/tests/genui-file-tree.spec.tsx
+++ b/tests/genui-file-tree.spec.tsx
@@ -85,6 +85,37 @@ function assertFileTreeLayout(container: HTMLElement): void {
   expect(container.textContent).toContain('README.md')
 }
 
+describe('host isolation contract', () => {
+  // The plugin must never restyle the host: styles are confined to the fence
+  // subtree. A bare element selector (`pre {}`, `button {}`) or a `:global`
+  // block would reach the host's own UI.
+  for (const file of ['GenuiBlock.module.css', 'PlotBlock.module.css']) {
+    it(`${file} stays scoped to its own classes`, () => {
+      const raw = readFileSync(join(process.cwd(), 'src/client', file), 'utf8')
+      expect(raw).not.toContain(':global')
+      // Keyframe stops (`0%`, `from`, `to`) are not selectors.
+      const src = raw.replace(/@keyframes[^{]*\{(?:[^{}]*\{[^}]*\}\s*)*\}/g, '')
+      const offenders: string[] = []
+      for (const match of src.matchAll(/(?:^|\n)([^\n{}/][^\n{]*?)\{/g)) {
+        const selector = (match[1] ?? '').trim()
+        if (selector === '' || selector.startsWith('@') || selector.startsWith('/*')) continue
+        for (const part of selector.split(',').map(p => p.trim())) {
+          if (part === '') continue
+          // Scoping rule: every selector must be ANCHORED by one of our module
+          // classes somewhere. `.table th`, `.card > :last-child` and
+          // `body[data-ds-dark-theme] .panel` are all contained; a bare
+          // `pre { }` or `body { }` would reach the host.
+          if (!/\./.test(part)) {
+            offenders.push(selector.slice(0, 60))
+            break
+          }
+        }
+      }
+      expect(offenders).toEqual([])
+    })
+  }
+})
+
 describe('component design contract (measured defects)', () => {
   const css = () => readFileSync(join(process.cwd(), 'src/client/GenuiBlock.module.css'), 'utf8')
 


### PR DESCRIPTION
「不改宿主系统」这条约束固化成测试：\n\n- 两个模块 CSS 禁止 `:global`；\n- 每条选择器必须被至少一个模块 class 锚定（`.table th` / `.card > :last-child` / `body[data-ds-dark-theme] .panel` 合规；裸 `pre {}` 判失败）；\n- 扫描前剔除 `@keyframes`（否则 `0%`/`from`/`to` 误判）。\n\n现状：0 处泄漏。唯一跨界的是 `.block * / .panel *` 的 box-sizing 重置，作用域限在自己子树内。