### PR TITLE
feat(inline): 行内富文本——文字类回答的底座

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -116,6 +116,19 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 
 **别用的情况**：一句话能说清的事、纯闲聊、用户明确说不要 UI、以及"为了炫技硬塞"——组件服务内容，不是内容服务组件。
 
+## 行内富文本（文字类回答的底座）
+
+`text.content`、`list` 项、`table` 文本列、`keyvalue` 值、`callout` 标题与正文里可以直接写四种行内标记——**重点留在句子里，不必为一个词单起一个组件**：
+
+| 写法 | 渲染 |
+|---|---|
+| `` `code` `` | 行内代码胶囊 |
+| `**加粗**` | 强调（不换行、不成块） |
+| `==高亮==` | 极淡底色标记 |
+| `[文字](https://…)` | 行内链接（http/https/mailto；非法目标退化为纯文字） |
+
+不嵌套、不解析 HTML（每个标记生成 React 元素，不走 innerHTML）；标记没闭合时原样显示。数值列 / badge / spark 单元格不解析（数字没什么可强调的）。
+
 ## 回答级版式：默认无卡，焦点唯一
 
 **规则来自设计规范，不是口味**（`design` skill 的 `references/design-reference.md`）：

--- a/src/client/GenuiBlock.module.css
+++ b/src/client/GenuiBlock.module.css
@@ -388,6 +388,28 @@ img.mediaPlayer { aspect-ratio: 16 / 9; object-fit: cover; background: var(--dsl
 .heroTitle { font-size: 20px; font-weight: 700; letter-spacing: -0.01em; color: var(--dsw-alias-label-primary); line-height: 1.3; }
 .heroSubtitle { font-size: var(--dsl-g-font-title); color: var(--dsw-alias-label-secondary); line-height: 1.6; text-wrap: pretty; }
 
+/* ---------- inline markup (inline.ts) ----------
+   Emphasis that stays INSIDE a sentence: a paragraph should not have to be
+   split into several nodes to bold one phrase. */
+.inlineCode {
+  font-family: var(--dsl-g-font-mono);
+  font-size: 0.92em;
+  padding: 1px 5px;
+  border-radius: 5px;
+  background: var(--dsl-g-surface);
+  border: 1px solid var(--dsl-g-border-surface);
+  white-space: nowrap;
+}
+.inlineStrong { font-weight: 680; color: var(--dsw-alias-label-primary); }
+.inlineMark {
+  background: color-mix(in srgb, var(--dsl-g-accent) 20%, transparent);
+  color: inherit;
+  padding: 0 3px;
+  border-radius: 4px;
+}
+.inlineLink { color: var(--dsl-g-accent); text-decoration: underline; text-underline-offset: 2px; }
+.inlineLink:hover { text-decoration-thickness: 2px; }
+
 /* ---------- badges / stat / progress ---------- */
 
 .badge {

--- a/src/client/blocks/advanced.tsx
+++ b/src/client/blocks/advanced.tsx
@@ -6,6 +6,7 @@
  */
 import { memo, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react'
 import { CodeBlock, DiffBlock, JsonTree, writeClipboard } from '@deepseek-ai/dsh-client-ui-primitives'
+import { renderInline } from '../inline.ts'
 import css from '../GenuiBlock.module.css'
 import { GENUI_LIMITS } from '../genui-runtime/index.ts'
 import { PlotBlock } from '../PlotBlock.tsx'
@@ -27,8 +28,8 @@ export const CalloutNode = memo(function CalloutNode({ node }: { node: GenuiCall
   const toneClass = CALLOUT_TONES[tone] ?? css.calloutInfo
   return (
     <div className={`${css.callout} ${toneClass}`} data-genui-callout>
-      {node.title !== undefined && <div className={css.calloutTitle}>{node.title}</div>}
-      <div className={css.calloutBody}>{node.content}</div>
+      {node.title !== undefined && <div className={css.calloutTitle}>{renderInline(node.title)}</div>}
+      <div className={css.calloutBody}>{renderInline(node.content)}</div>
     </div>
   )
 })
@@ -64,7 +65,7 @@ export const KeyValueNode = memo(function KeyValueNode({ node }: { node: GenuiKe
       {pairs.map((pair, i) => (
         <div key={i} className={css.kvRow}>
           <dt className={css.kvKey}>{pair.key}</dt>
-          <dd className={css.kvValue}>{pair.value}</dd>
+          <dd className={css.kvValue}>{renderInline(pair.value)}</dd>
         </div>
       ))}
     </dl>

--- a/src/client/blocks/charts.tsx
+++ b/src/client/blocks/charts.tsx
@@ -13,6 +13,7 @@
 import { Fragment, memo, useCallback, useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { MouseEvent as ReactMouseEvent, ReactNode, RefObject } from 'react'
 import { writeClipboard } from '@deepseek-ai/dsh-client-ui-primitives'
+import { renderInline } from '../inline.ts'
 import css from '../GenuiBlock.module.css'
 import { GENUI_LIMITS } from '../genui-runtime/index.ts'
 import type { GenuiChart, GenuiTable } from '../spec.ts'
@@ -318,7 +319,9 @@ export const TableNode = memo(function TableNode({ node, renderDetail, filterVal
                 : type === 'index'
                   ? <span className={css.cellIndex}>{rowIndex + 1}</span>
                   : tone === null
-                    ? String(cell)
+                    // Text cells honour inline markup; numeric/badge/spark
+                    // cells stay literal (a number has nothing to emphasise).
+                    ? renderInline(String(cell))
                     : <span className={`${css.tdDelta} ${tone === 'up' ? css.tdDeltaUp : css.tdDeltaDown}`}>{String(cell)}</span>}
       </td>
     )

--- a/src/client/blocks/render-node.tsx
+++ b/src/client/blocks/render-node.tsx
@@ -8,6 +8,7 @@ import { type ComponentType, type ReactNode, useEffect, useState, type CSSProper
 import * as primitives from '@deepseek-ai/dsh-client-ui-primitives'
 import css from '../GenuiBlock.module.css'
 import { GENUI_LIMITS } from '../genui-runtime/index.ts'
+import { renderInline } from '../inline.ts'
 import type { GenuiList, GenuiNode } from '../spec.ts'
 import type { AnswersState, GenuiBlockProps } from './state.ts'
 import { AudioNode, avatarColor, ClickFeedbackButton, VideoNode } from './basic.tsx'
@@ -202,7 +203,7 @@ export function renderNode(
       const size = node.size ?? 'body'
       return (
         <div key={key} className={`${css.text} ${css[size]}` + (node.center ? ` ${css.center}` : '')}>
-          {node.content}
+          {renderInline(node.content)}
         </div>
       )
     }
@@ -412,7 +413,7 @@ export function renderNode(
             <div key={i} className={css.li}>
               {isListItemNode(item)
                 ? renderNode(item, i, onAction, depth + 1, answers)
-                : <><span className={css.liTitle}>{typeof item === 'string' ? item : item.title}</span>{typeof item !== 'string' && item.desc !== undefined && <span className={css.liDesc}>{item.desc}</span>}</>}
+                : <><span className={css.liTitle}>{renderInline(typeof item === 'string' ? item : item.title)}</span>{typeof item !== 'string' && item.desc !== undefined && <span className={css.liDesc}>{renderInline(item.desc)}</span>}</>}
             </div>
           ))}
           {bound !== undefined && <span className={css.filterHint}>匹配 {items.length} / {all.length} 项</span>}

--- a/src/client/inline.ts
+++ b/src/client/inline.ts
@@ -1,0 +1,73 @@
+/**
+ * Minimal inline markup for text-bearing fields.
+ *
+ * Prose-heavy answers need emphasis INSIDE a sentence: a command, a term, a key
+ * phrase, a link. Until now every field was a plain string, so emphasis meant
+ * splitting one sentence into several nodes and the paragraph read as broken.
+ *
+ * Supported (deliberately tiny, no nesting):
+ *   `code`            inline code chip
+ *   **bold**          emphasis that does not wrap or become a block
+ *   ==mark==          highlight
+ *   [text](https://…) inline link (http/https/mailto only)
+ *
+ * Safety: this NEVER produces HTML. Each token becomes a React element, so the
+ * host's HTML parser is never involved (the whole client builds elements, the
+ * only innerHTML in the project is mermaid's sanitized SVG). An unterminated or
+ * unknown marker is rendered literally rather than erroring, and a link whose
+ * href fails {@link safeHref} degrades to its label text.
+ * @module @changfenhuang/dsh-genui/client/inline
+ */
+import { createElement, type ReactNode } from 'react'
+import css from './GenuiBlock.module.css'
+import { safeHref } from './genui-runtime/value-utils.ts'
+
+/** One pass, no nesting: each alternative is a self-contained token. */
+// Links match ANY target here and are validated by safeHref afterwards, so a
+// `javascript:` target degrades to its label text instead of showing as raw
+// markup the reader has to parse themselves.
+const INLINE = /`[^`\n]+`|\*\*[^*\n]+\*\*|==[^=\n]+==|\[[^\]\n]+\]\([^)\s]+\)/g
+
+/** True when the string contains anything the parser understands. */
+export function hasInlineMarkup(text: string): boolean {
+  return typeof text === 'string' && /[`*=]|\[/.test(text)
+}
+
+/**
+ * Render one string as React nodes with inline markup applied.
+ * @param text - the raw field value.
+ * @returns the original string when nothing matched, else the node list.
+ */
+export function renderInline(text: string): ReactNode {
+  if (typeof text !== 'string' || text === '' || !hasInlineMarkup(text)) return text
+  const out: ReactNode[] = []
+  let last = 0
+  let key = 0
+  for (const match of text.matchAll(INLINE)) {
+    const index = match.index ?? 0
+    const token = match[0]
+    if (index > last) out.push(text.slice(last, index))
+    if (token.startsWith('`')) {
+      out.push(createElement('code', { key: key++, className: css.inlineCode }, token.slice(1, -1)))
+    } else if (token.startsWith('**')) {
+      out.push(createElement('strong', { key: key++, className: css.inlineStrong }, token.slice(2, -2)))
+    } else if (token.startsWith('==')) {
+      out.push(createElement('mark', { key: key++, className: css.inlineMark }, token.slice(2, -2)))
+    } else {
+      const parts = /^\[([^\]\n]+)\]\(([^)\s]+)\)$/.exec(token)
+      if (parts === null) {
+        out.push(token)
+      } else {
+        const href = safeHref(parts[2])
+        out.push(href === undefined
+          ? parts[1]
+          : createElement('a', {
+            key: key++, className: css.inlineLink, href, target: '_blank', rel: 'noreferrer noopener',
+          }, parts[1]))
+      }
+    }
+    last = index + token.length
+  }
+  if (last < text.length) out.push(text.slice(last))
+  return out.length === 0 ? text : out
+}

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -103,12 +103,13 @@ The spec is a white-listed component tree rendered inline where the fence sits. 
 **默认就该出 UI**：出现下列情况至少出一个围栏：
 - ≥3 条并列要点 → \`list\`；数字对比 → \`table\`；指标/进度/状态 → \`stat\`/\`progress\`/\`badge\`
 - 步骤/时间线 → \`steps\`/\`timeline\`/\`mermaid\`；架构/流程 → \`diagram\` 或 \`mermaid\`；风险/结论 → \`callout\`；代码/改动 → \`code\`/\`diff\`/\`json\`
+- 行内富文本：\`text\`/\`list\`/表格文本列/\`keyvalue\`/\`callout\` 里可写 \`code\`、**加粗**、==高亮==、[文字](url)：重点留在句中，不必为一个词单起组件。
 - 默认无卡 ≠ 少用组件：上面的硬触发照常出组件；「无卡」只约束**不要把纯文字段落包进卡片**（单段文字用「标题 + 正文 + 间距」，不用 ①②③ 装饰编号）。一条回答只有一个视觉焦点，其余权重明显更低；同一批数据不做两种表达；hero 一条最多一个。
 
 **发回答前最后自检一次**：这段内容里有没有 ≥3 条并列要点、任何对比、任何数字/指标、任何步骤或流程？有就先转成组件再开口。**状态汇报、进度说明、提交与改动清单同样算**——不要因为它是"说明文"就用纯文字写。这一条踩过的坑：连续几条汇报全靠文字，一条围栏都没发。
 - 趋势/占比 → \`chart\`（≤8 点）或 \`echart\`（多序列/要交互时）；配色默认跟随主题，只有语义需要时才用 \`palette\` / \`card.accent\`；排版用 grid 子节点的 \`"span":2\` 跨列做宽窄混排（bento），不要一列方块堆到底；数据多时给 \`table\`/\`chart\`/\`list\` 配一个 \`input\`(id) + \`filter\` 绑定，读者能就地筛选，不用再问一遍
 
-**字段速查**（完整见 genui skill）：\`stat\` \`{"label":"…","value":"…","delta":"+1.2%"}\` · \`table\` \`{"columns":["…"],"rows":[["…"]],"types":["…"]?,"total":true?,"details":[[…]]?,"filter":"输入框id"?,"sortField":"下拉id"?,"export":true?}\` · \`callout\` \`{"tone":"info|success|warning|error","title":"…","content":"…"}\` · \`progress\` \`{"value":72,"variant":"ring"?,"target":80?}\`
+**字段速查**（完整见 genui skill）：\`stat\` \`{"label","value","delta"?}\` · \`table\` \`{"columns","rows","types"?,"total"?,"details"?,"filter"?,"export"?}\` · \`callout\` \`{"tone","title","content"}\` · \`progress\` \`{"value","variant"?,"target"?}\`
 
 Rules:
 - JSON 严格: 坏围栏降级为代码块；≥3 节点或含 table 的围栏发出前调用 validate_dsh_ui，❌ 修好再发（若附「已自动修复」JSON 照抄即可）。

--- a/tests/genui-inline.spec.tsx
+++ b/tests/genui-inline.spec.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+// Inline markup: emphasis INSIDE a sentence. Every token must become a React
+// element — never HTML — and an unsafe link must degrade to its label.
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { renderInline } from '../src/client/inline.ts'
+
+afterEach(cleanup)
+
+const html = (text: string): string => {
+  const { container } = render(<div>{renderInline(text)}</div>)
+  return container.innerHTML
+}
+
+describe('inline markup', () => {
+  it('renders code, bold, mark and an https link as elements', () => {
+    const out = html('跑 `npm run build`，**一定要**看 ==退出码==，见 [文档](https://example.com/a)')
+    expect(out).toContain('<code')
+    expect(out).toContain('<strong')
+    expect(out).toContain('<mark')
+    expect(out).toContain('href="https://example.com/a"')
+    expect(out).toContain('rel="noreferrer noopener"')
+    // The literal markers must be gone from the visible text.
+    expect(out).not.toContain('`')
+    expect(out).not.toContain('**')
+    expect(out).not.toContain('==')
+  })
+
+  it('leaves an unterminated marker literal instead of throwing', () => {
+    expect(html('这里有 **没闭合的加粗')).toContain('**没闭合的加粗')
+    expect(html('只有一个反引号 ` 在里面')).toContain('`')
+  })
+
+  it('refuses a non-http(s) link and keeps only its label', () => {
+    const out = html('[点我](javascript:alert(1))')
+    expect(out).not.toContain('javascript:')
+    expect(out).not.toContain('<a')
+    expect(out).toContain('点我')
+  })
+
+  it('never emits HTML from the source text', () => {
+    const out = html('<img src=x onerror=alert(1)> 与 **加粗**')
+    expect(out).not.toContain('<img')
+    expect(out).toContain('&lt;img')
+  })
+
+  it('returns the plain string untouched when there is no markup', () => {
+    // Identity: the fast path must not wrap plain prose in extra elements.
+    const plain = '完全没有标记的一句话'
+    expect(renderInline(plain)).toBe(plain)
+    expect(html(plain)).toBe('<div>完全没有标记的一句话</div>')
+  })
+})


### PR DESCRIPTION
用户问「文字为主的回答，有什么还没设计好的组件」，然后就做了排第一的那个：**行内富文本**。

**为什么它是文字类回答的底座**：`text.content`、`list` 项、表格文本列、`keyvalue` 值、`callout` 标题与正文此前**全是纯字符串**，没有任何行内格式。想强调一句话里的关键词，只能把句子拆成多个节点——读起来是断的。这不是"缺一个组件"，是所有解释类回答的公共缺口。

支持四种（**刻意做小，不支持嵌套**）：

| 写法 | 渲染 |
|---|---|
| `` `code` `` | 行内代码胶囊 |
| `**加粗**` | 强调，不换行不成块 |
| `==高亮==` | 极淡底色标记 |
| `[文字](https://…)` | 行内链接 |

**安全**：全程**不产生 HTML**——每个标记生成 React 元素，宿主的 HTML 解析器根本不参与（全项目只有 mermaid 用 innerHTML，且是 sanitize 过的）。链接目标一律过 `safeHref`：`javascript:` 这类非法目标**退化成纯文字标签**（有测试钉住）。标记没闭合时原样显示，不报错。数值 / badge / spark 单元格不解析。

**未改宿主**：新增的只有 `src/client/inline.ts` + 四条 CSS 类；宿主隔离契约测试（`#145`）在这条分支上仍然通过。

验证：tsc · 556 测试（新增 5 条：四种标记、未闭合、非法链接、HTML 注入、纯文本快路径）· 构建 · 视觉 E2E 12 项全绿。段落长度 3159 / 3200（为放这一行，把字段速查压成了属性名列表）。
