### PR TITLE
fix(test): 范例测试按块声明意图（原版禁止文档写反例）

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -172,7 +172,7 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 
 ### 1. 状态汇报（多点 + 有构图）
 
-```json
+```json dsh-ui
 {"items":[{"type":"grid","cols":4,"items":[{"type":"stat","label":"已合并","value":"26","delta":"#123–#148"},{"type":"stat","label":"未合并","value":"0"},{"type":"stat","label":"测试","value":"556","delta":"全绿"},{"type":"stat","label":"组件","value":"45"}]},{"type":"table","columns":["层","状态","生效方式"],"types":["text","badge","text"],"rows":[["组件与样式","已生效","每次从磁盘读"],["系统提示","待重启","Node 半只在启动时加载"]]},{"type":"callout","tone":"info","title":"结论","content":"改动都上了，但 **效果还没证据**。"}]}
 ```
 
@@ -180,7 +180,7 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 
 ### 2. 解释/教学（文字为主，一个点睛组件）
 
-```json
+```json dsh-ui
 {"items":[{"type":"text","size":"body","content":"根因不是记性，是规则自相矛盾：一条说「≥3 条并列 → 出 list」，另一条说「组件只在 ==文字表达会更差== 时出现」。"},{"type":"list","items":[{"title":"先修规则","desc":"把闸门限定为「不要包卡片」，而不是「少用组件」"},{"title":"再看数据","desc":"如果漏发率不降，才考虑兜底手段"}]},{"type":"callout","tone":"warning","title":"别急着加监控","content":"事后提醒来得太晚，还会逼人在不需要组件的地方硬塞。"}]}
 ```
 
@@ -188,15 +188,23 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 
 ### 3. 对比选型
 
-```json
+```json dsh-ui
 {"items":[{"type":"table","columns":["方案","代价","判断"],"types":["text","text","badge"],"rows":[["改规则","改一行字","推荐"],["加看门狗","事后才提醒，会变噪音","不推荐"]]},{"type":"callout","tone":"success","title":"选前者","content":"成本一行，且解决根因。"}]}
 ```
 
 不要这样：表格里放同一批数据后又画一张图。
 
+反例（这条会被围栏校验直接拒绝，所以别抄）：
+
+```json dsh-ui-bad
+{"items":[{"type":"chart","kind":"donut","data":[{"label":"A","value":1}],"series":[{"label":"B","data":[{"label":"B","value":2}]}]}]}
+```
+
+为什么拒：`series` 只对 `bars`/`line` 有效；环形图给了 `series` 属于契约冲突，围栏会**静默降级为代码块**。
+
 ### 4. 排查诊断（顺序即叙事）
 
-```json
+```json dsh-ui
 {"items":[{"type":"steps","current":1,"steps":[{"title":"复现","desc":"滚动页面时光标压在图上"},{"title":"定位","desc":"onWheel 无条件 preventDefault"},{"title":"修复","desc":"改为仅 ⌘/Ctrl + 滚轮缩放"}]},{"type":"diff","diffs":[{"path":"PlotBlock.tsx","oldText":"e.preventDefault()","newText":"if (!e.metaKey && !e.ctrlKey) return"}]},{"type":"callout","tone":"info","title":"另外补了退路","content":"视图偏离时显示当前区间并提供 ==回到初始区间==。"}]}
 ```
 
@@ -204,7 +212,7 @@ description: "Render structured interactive UI inline in your reply via the dsh-
 
 ### 5. 数据结论（一个主图 + 明细）
 
-```json
+```json dsh-ui
 {"items":[{"type":"chart","kind":"line","data":[],"series":[{"label":"本周","data":[{"label":"一","value":8},{"label":"二","value":12},{"label":"三","value":9}]}]},{"type":"table","columns":["时段","量","环比"],"types":["text","num","delta"],"rows":[["周一","8","-4%"],["周二","12","+50%"]]}]}
 ```
 

--- a/tests/genui-skill-examples.spec.ts
+++ b/tests/genui-skill-examples.spec.ts
@@ -1,7 +1,13 @@
-// Every JSON example in SKILL.md must survive the REAL fence pipeline
-// (parse -> chart contract -> repair -> render gate). An example that cannot
-// render teaches the wrong shape: the model copies it and the fence silently
-// degrades to a code block.
+// SKILL.md examples are copy-paste material: a model will reuse them verbatim,
+// so an example that cannot render teaches a broken shape (the fence silently
+// degrades to a code block on the user's machine).
+//
+// The fence info string declares the intent, because documentation must also be
+// allowed to show FRAGMENTS and ANTI-EXAMPLES:
+//   ```json dsh-ui       -> must render (contract + repair + render gate)
+//   ```json dsh-ui-bad   -> must be REJECTED (proves the documented "don't do
+//                           this" really is rejected by the very guard)
+//   ```json              -> free-form fragment, not asserted
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -9,21 +15,35 @@ import { processGenuiSpec, isRenderableProcess } from '../src/client/guard.ts'
 import { validateRenderableChartSemantics } from '../src/plugin/chart-contract.ts'
 
 const skill = readFileSync(join(process.cwd(), 'SKILL.md'), 'utf8')
-const blocks = [...skill.matchAll(/```json\n([\s\S]*?)\n```/g)].map(m => m[1]!)
+const blocksOf = (tag: string): string[] =>
+  [...skill.matchAll(new RegExp('```json ' + tag + '\\n([\\s\\S]*?)\\n```', 'g'))].map(m => m[1]!)
+const renders = (raw: string): boolean => {
+  const spec = JSON.parse(raw)
+  return validateRenderableChartSemantics(spec).length === 0 && isRenderableProcess(processGenuiSpec(spec))
+}
 
 describe('SKILL.md examples', () => {
-  it('ships five renderable examples plus a no-component counter-example', () => {
-    expect(blocks.length).toBeGreaterThanOrEqual(5)
-    // The prose example matters as much: without it a model learns "always
-    // emit something", which is how short answers get wrapped in boxes.
+  const good = blocksOf('dsh-ui')
+  const bad = blocksOf('dsh-ui-bad')
+
+  it('ships copy-pasteable examples and at least one anti-example', () => {
+    expect(good.length).toBeGreaterThanOrEqual(5)
+    expect(bad.length).toBeGreaterThanOrEqual(1)
+    // Without a no-component example a model learns "always emit something".
     expect(skill).toContain('正确地不套组件')
   })
 
-  for (const [i, raw] of blocks.entries()) {
+  for (const [i, raw] of good.entries()) {
     it(`example ${i + 1} renders`, () => {
-      const spec = JSON.parse(raw)
-      expect(validateRenderableChartSemantics(spec)).toEqual([])
-      expect(isRenderableProcess(processGenuiSpec(spec))).toBe(true)
+      expect(renders(raw)).toBe(true)
+    })
+  }
+
+  for (const [i, raw] of bad.entries()) {
+    it(`anti-example ${i + 1} is really rejected`, () => {
+      // The doc claims this shape fails; if the guard ever accepts it, the
+      // documentation is lying and this test says so.
+      expect(renders(raw)).toBe(false)
     })
   }
 })


### PR DESCRIPTION
用户批注「这不合理吧」，对了一半：

**不合理的那半**：原测试要求 SKILL.md 里**每一个** JSON 块都是合法 spec，等于**禁止文档写反例**（"❌ 不要这样"）和**片段**（只展示几个字段）——而反例恰恰是文档最有价值的部分。而且这几个范例是我照着管线写出来的，"能过"属于回归兜底，不是证明。

**该保留的那半**：模型会**原样照抄**范例。范例里若有不存在字段或组件，抄出来会在用户机器上**静默降级成代码块**——这种错最难发现。

所以约束不删，改成**按块声明意图**：

| 块标记 | 断言 |
|---|---|
| ` ```json dsh-ui ` | 必须通过真实管线（可直接抄的范例） |
| ` ```json dsh-ui-bad ` | **必须被拒绝**——文档化的反例 |
| ` ```json ` | 片段，不断言 |

反例那条是**双向验证**：它证明文档里"这样会被拦下"的说法确实成立；守卫哪天放宽了，测试立刻报错。已补一个真实反例（环形图给 `series` → 契约冲突 → 静默降级）并写明原因。

验证：tsc · 562 测试（范例测试 7 条：5 正例 + 1 反例 + 1 结构断言）· 构建。
