### PR TITLE
fix(diagram): 配色跟随宿主 + 去水印 + 高度贴合 + 图例不截断

### DIFF
--- a/scripts/e2e-visual.mts
+++ b/scripts/e2e-visual.mts
@@ -251,6 +251,7 @@ try {
     ['steps', '[class*="steps"]'],
     ['timeline', '[class*="timeline"]'],
     ['mermaid', '[data-genui] svg[id^="mermaid"], [class*="mermaid"] svg'],
+    ['diagram', '[class*="diagram"]'],
     ['quiz', '[class*="quiz"]'],
     ['media', '[class*="media"]'],
     ['kv', '[class*="kvRow"]'],

--- a/src/client/blocks/diagram/index.tsx
+++ b/src/client/blocks/diagram/index.tsx
@@ -20,7 +20,16 @@ const FONT_MONO = "'Geist Mono', ui-monospace, 'SF Mono', monospace"
 
 /** Editorial constants (diagram-design §5–7). */
 const NODE_H = 64 // node box height (48→64 for the editorial ramp)
-const LEGEND_H = 56
+const LEGEND_COL_W = 150
+const LEGEND_ROW_H = 22
+const LEGEND_ITEMS: Array<{ label: string; type: string | undefined }> = [
+  { label: 'Focal', type: 'focal' },
+  { label: 'Backend', type: 'backend' },
+  { label: 'Store', type: 'store' },
+  { label: 'External', type: 'external' },
+  { label: 'Optional', type: 'optional' },
+  { label: 'Security', type: 'security' },
+]
 
 /**
  * Compute a deterministic parent map for tree-like kinds: the first edge
@@ -34,14 +43,13 @@ function buildParentMap(edges: Array<{ from: string; to: string }>): (id: string
   return id => parents.get(id)
 }
 
-/** Render one node box + its text content (tag / name / sublabel / index). */
+/** Render one node box + its text content (tag / name / sublabel). */
 function renderNodeBox(
   box: Box,
   label: string,
   sub: string | undefined,
   type: string | undefined,
   tag: string | undefined,
-  index: number,
   palette: ReturnType<typeof resolvePalette>,
 ): React.ReactNode {
   const treatment = nodeTreatment(type, palette)
@@ -72,7 +80,6 @@ function renderNodeBox(
         </>
       )}
       {/* Index number: bottom-right, half-transparent, editorial big numeral */}
-      <text x={box.x + box.w - 6} y={box.y + box.h - 6} fill={inkAt(treatment.stroke, 0.12)} fontSize={24} fontWeight={600} fontFamily={FONT_MONO} textAnchor="end">{String(index).padStart(2, '0')}</text>
       <text x={cx} y={nameY} fill={palette.ink} fontSize={12} fontWeight={600} fontFamily={FONT_SANS} textAnchor="middle">{label}</text>
       {sub !== undefined && (
         <text x={cx} y={subY} fill={palette.soft} fontSize={9} fontFamily={FONT_MONO} textAnchor="middle">{sub}</text>
@@ -162,26 +169,19 @@ function renderZone(z: { label: string; x: number; y: number; w: number; h: numb
 }
 
 /** Legend strip at the bottom: hairline separator + treatment swatches. */
-function renderLegend(palette: ReturnType<typeof resolvePalette>): React.ReactNode {
-  const items: Array<{ label: string; type: string | undefined }> = [
-    { label: 'Focal', type: 'focal' },
-    { label: 'Backend', type: 'backend' },
-    { label: 'Store', type: 'store' },
-    { label: 'External', type: 'external' },
-    { label: 'Optional', type: 'optional' },
-    { label: 'Security', type: 'security' },
-  ]
+function renderLegend(palette: ReturnType<typeof resolvePalette>, items: typeof LEGEND_ITEMS, width: number, cols: number): React.ReactNode {
   return (
     <g>
-      <line x1={40} y1={0} x2={1000} y2={0} stroke={inkAt(palette.ink, 0.10)} strokeWidth={0.8} />
+      <line x1={40} y1={0} x2={Math.max(120, width - 40)} y2={0} stroke={inkAt(palette.ink, 0.10)} strokeWidth={0.8} />
       <text x={40} y={16} fill={palette.soft} fontSize={8} fontFamily={FONT_MONO} letterSpacing={1.6}>LEGEND</text>
       {items.map((item, i) => {
         const t = nodeTreatment(item.type, palette)
-        const x = 40 + i * 170
+        const x = 40 + (i % cols) * LEGEND_COL_W
+        const y = 32 + Math.floor(i / cols) * LEGEND_ROW_H
         return (
           <g key={item.label}>
-            <rect x={x} y={32} width={14} height={10} rx={2} fill={t.fill} stroke={t.stroke} strokeWidth={1} strokeDasharray={t.dashed === true ? '3,2' : undefined} />
-            <text x={x + 20} y={41} fill={palette.soft} fontSize={8.5} fontFamily={FONT_SANS}>{item.label}</text>
+            <rect x={x} y={y} width={14} height={10} rx={2} fill={t.fill} stroke={t.stroke} strokeWidth={1} strokeDasharray={t.dashed === true ? '3,2' : undefined} />
+            <text x={x + 20} y={y + 9} fill={palette.soft} fontSize={8.5} fontFamily={FONT_SANS}>{item.label}</text>
           </g>
         )
       })}
@@ -205,6 +205,8 @@ function nextUid(): string {
 /** The `diagram` node renderer. */
 export function DiagramNode({ node }: { node: GenuiDiagram }) {
   const uid = useMemo(nextUid, [])
+  // Host tokens are read from the document (with body/root fallbacks), so the
+  // palette follows the surrounding UI instead of a hardcoded editorial skin.
   const palette = useMemo(() => resolvePalette(node.variant, node.theme), [node.variant, node.theme])
   const layout = useMemo(() => resolveLayout(node, buildParentMap(node.edges ?? [])), [node])
 
@@ -226,7 +228,15 @@ export function DiagramNode({ node }: { node: GenuiDiagram }) {
 
   // Canvas: content bounds + editorial chrome (bottom legend strip).
   const contentH = layout.height
-  const canvasH = contentH + LEGEND_H + 24
+  // Legend: only the types this diagram actually uses, wrapped to the canvas
+  // width (the old fixed 170px pitch + hardcoded 1000px rule overflowed any
+  // narrow canvas and printed "Extern…").
+  const legendItems = LEGEND_ITEMS.filter(item => item.type !== undefined
+    && nodes.some(n => (n.node.type ?? 'backend') === item.type))
+  const legendCols = Math.max(1, Math.floor((layout.width - 40) / LEGEND_COL_W))
+  const legendRows = Math.max(1, Math.ceil(legendItems.length / legendCols))
+  const legendH = 24 + legendRows * LEGEND_ROW_H
+  const canvasH = contentH + legendH + 12
 
   return (
     <figure className="genui-diagram" data-genui-diagram>
@@ -264,19 +274,19 @@ export function DiagramNode({ node }: { node: GenuiDiagram }) {
         </g>
         {/* nodes after edges */}
         <g>
-          {nodes.map((l, idx) => {
+          {nodes.map(l => {
             const effectiveType = l.node.type === 'focal' && focalSeen >= focalBudget ? undefined : l.node.type
             if (l.node.type === 'focal') focalSeen += 1
             return (
               <g key={l.node.id}>
-                {renderNodeBox(l.box, l.node.label, l.node.sub, effectiveType, l.node.tag, idx + 1, palette)}
+                {renderNodeBox(l.box, l.node.label, l.node.sub, effectiveType, l.node.tag, palette)}
               </g>
             )
           })}
         </g>
         {/* legend strip */}
         <g transform={`translate(0, ${contentH + 8})`}>
-          {renderLegend(palette)}
+          {renderLegend(palette, legendItems, layout.width, legendCols)}
         </g>
       </svg>
     </figure>

--- a/src/client/blocks/diagram/layout.ts
+++ b/src/client/blocks/diagram/layout.ts
@@ -191,7 +191,10 @@ export function resolveLayout(
     height = Math.max(height, l.box.y + l.box.h)
   }
   width = Math.max(320, Math.ceil((width + MARGIN) / 4) * 4)
-  height = Math.max(200, Math.ceil((height + MARGIN) / 4) * 4)
+  // Hug the content: the old 200px floor plus the legend strip made a 4-node
+  // single row render inside a canvas twice its needed height, and the SVG
+  // scales to the container width, so the empty band was amplified on screen.
+  height = Math.max(96, Math.ceil((height + MARGIN) / 4) * 4)
 
   const edgesOut: LayoutEdge[] = edges.map(e => ({ edge: e, fromId: e.from, toId: e.to }))
 

--- a/src/client/blocks/diagram/theme.ts
+++ b/src/client/blocks/diagram/theme.ts
@@ -49,9 +49,47 @@ const DARK: DiagramPalette = {
   link: '#6a95d8',
 }
 
+/** Read one host token from the element, then body, then the root. */
+function token(name: string, fallback: string, el?: Element | null): string {
+  if (typeof document === 'undefined') return fallback
+  const hosts: Array<Element | null> = [el ?? null, document.body, document.documentElement]
+  for (const host of hosts) {
+    if (host === null) continue
+    const value = getComputedStyle(host).getPropertyValue(name).trim()
+    if (value !== '') return value
+  }
+  return fallback
+}
+
+/**
+ * Palette derived from the HOST design tokens.
+ *
+ * The hardcoded editorial skin (paper #f5f5f5, orange accent #eb6c36) has
+ * nothing to do with the surrounding UI: a diagram dropped into a light chat
+ * came out as a grey slab with a salmon "focal" node. SVG attributes cannot
+ * resolve CSS variables, so the tokens are read as literals here — same
+ * approach as the ECharts theming.
+ */
+export function hostPalette(el?: Element | null): DiagramPalette {
+  const accent = token('--dsw-alias-state-business-primary', '#4f8ef7', el)
+  return {
+    paper: token('--dsw-alias-bg-layer-2', '#ffffff', el),
+    paper2: token('--dsw-alias-bg-layer-3', '#f5f5f5', el),
+    ink: token('--dsw-alias-label-primary', '#2d3142', el),
+    muted: token('--dsw-alias-label-secondary', '#4f5d75', el),
+    soft: token('--dsw-alias-label-tertiary', '#7a8399', el),
+    rule: token('--dsw-alias-border-l2', 'rgba(45,49,66,0.12)', el),
+    accent,
+    accentTint: `color-mix(in srgb, ${accent} 10%, transparent)`,
+    link: accent,
+  }
+}
+
 /** Resolve the active palette from variant + optional theme overrides. */
-export function resolvePalette(variant: GenuiDiagramVariant | undefined, theme: GenuiDiagramTheme | undefined): DiagramPalette {
-  const base = variant === 'dark' ? DARK : LIGHT
+export function resolvePalette(variant: GenuiDiagramVariant | undefined, theme: GenuiDiagramTheme | undefined, el?: Element | null): DiagramPalette {
+  // No explicit variant -> follow the host theme; an explicit variant keeps the
+  // editorial skin (that is what the field is for).
+  const base = variant === undefined ? hostPalette(el) : variant === 'dark' ? DARK : LIGHT
   if (theme === undefined) return base
   return {
     paper: theme.paper ?? base.paper,

--- a/src/client/gallery.ts
+++ b/src/client/gallery.ts
@@ -178,6 +178,12 @@ export const gallerySpec: GenuiSpec = {
     ] },
     { type: 'code', lang: 'json', code: '{"hello": "world"}' },
     { type: 'mermaid', code: 'graph TD\nA[模型] --> B[渲染器]\nB --> C[组件]' },
+    { type: 'diagram', kind: 'architecture', title: '架构图（配色跟随宿主令牌）', nodes: [
+      { id: 'm', label: '模型', type: 'external', x: 20, y: 40, w: 100, h: 44 },
+      { id: 'f', label: '围栏 JSON', type: 'focal', x: 160, y: 40, w: 112, h: 44 },
+      { id: 'g', label: 'guard', type: 'backend', x: 312, y: 40, w: 104, h: 44 },
+      { id: 's', label: '组件库', type: 'store', x: 456, y: 40, w: 100, h: 44 },
+    ], edges: [{ from: 'm', to: 'f' }, { from: 'f', to: 'g' }, { from: 'g', to: 's' }] },
     { type: 'scene3d', title: '几何演示', ambient: 1, meshes: [
       { shape: 'box', color: '#4f8ef7', position: [-1.4, 0, 0], rotation: [0.5, 0.8, 0] },
       { shape: 'sphere', color: '#3ecf8e', position: [0, 0, 0] },

--- a/src/client/guard.ts
+++ b/src/client/guard.ts
@@ -1061,7 +1061,11 @@ function repairDiagram(v: unknown): GenuiDiagram | null {
   const zones = repairDiagramZones(o.zones)
   if (zones === undefined) return null
   return {
-    type: 'diagram', kind, nodes, edges, zones,
+    // `zones` is optional: emitting `zones: []` made every diagram node differ
+    // from its input for no reason (and broke the "gallery survives the guard
+    // unchanged" contract).
+    type: 'diagram', kind, nodes, edges,
+    ...opt('zones', zones.length > 0 ? zones : undefined),
     ...opt('variant', enu(o.variant, DIAGRAM_VARIANTS)),
     ...opt('title', str(o.title, 256)),
     ...opt('theme', repairDiagramTheme(o.theme)),

--- a/tests/genui-diagram.spec.tsx
+++ b/tests/genui-diagram.spec.tsx
@@ -123,7 +123,10 @@ describe('DiagramNode', () => {
     expect(texts).toContain('FRONTEND')
     expect(texts).toContain('DATA')
     expect(texts).toContain('LEGEND')
-    expect(texts).toContain('Focal')
+    // The legend lists only the node types this diagram actually uses: two
+    // untyped nodes are `backend`, so `Backend` shows and unused roles do not.
+    expect(texts).toContain('Backend')
+    expect(texts).not.toContain('Security')
     // Zone hairline rects exist (dashed border + label mask + node boxes).
     expect(container.querySelectorAll('rect').length).toBeGreaterThanOrEqual(8)
   })


### PR DESCRIPTION
用户截图：「这玩意儿颜色这样不行吧」。查下来 diagram 用的是**硬编码的编辑风调色板**（纸面 `#f5f5f5`、强调色橙 `#eb6c36`），完全没跟宿主走——所以在浅色对话里 focal 节点是粉橙色、纸面是一块灰。SVG 属性无法解析 CSS 变量（与 ECharts 同样的限制），令牌必须在渲染时读成字面值。

| 问题 | 之前 | 现在 |
|---|---|---|
| 配色 | 硬编码橙 accent + 灰纸面 | `hostPalette()` 从宿主令牌派生；显式 `variant` 时才用编辑风皮肤 |
| 水印 | 24px / 12% 透明度的巨型序号 01/02/03 | 删除 |
| 空白 | 高度下限 200 → 再被容器宽度等比放大 | 下限 96，贴合内容（画布 679 → 505） |
| 图例 | 6 项 × 固定 170px + 硬编码 1000px 分隔线 → 印出 "Extern…" | 只列实际用到的类型 + 按宽度换行 + 真实分隔线 |

顺带两件：guard 不再给 diagram 补空的 `zones: []`（无谓地让节点与输入不相等）；画廊补上一直缺失的 diagram 样例（用吸附后的规范坐标，顺带让"画廊原样通过 guard"的契约继续成立）。

验证：tsc · 563 测试 · 构建 · 视觉 E2E 全绿；逐组件截图确认四项修复。
