### PR TITLE
fix(plugin): export plugin name per DSH plugin spec

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -129,6 +129,7 @@ Rules:
 // plugin — hosts without tool access keep the fence channel working. Cordis
 // inject entries are hard requirements, so the registry is probed at runtime
 // instead (see apply).
+export const name = '@changfenhuang/dsh-genui'
 export const inject = ['systemPrompt']
 
 const BUNDLED_SKILL_RANK = 600


### PR DESCRIPTION
Fixes #154

## Summary

按 DeepSeek Harness 官方插件开发文档（[develop/basic](https://deepseek-harness.github.io/deepseek-harness/develop/basic/)）的最小插件形式（`export const name` + `export function apply(ctx)`），为 host 入口补上缺失的 `name` 导出。

## Changes

- `src/plugin/index.ts`：在 `inject` 上方新增一行 `export const name = '@changfenhuang/dsh-genui'`（取自 package name，与文件头 `@module` 注释一致）。

## Testing

- [x] `pnpm run build`（tsc + tsdown）通过；构建产物导出列表由 `GENUI_SECTION_TEXT / apply / inject` 变为含 `name`
- [x] `pnpm test`：56 个测试文件、566 个用例全部通过（105 skipped 与本次改动无关）
